### PR TITLE
feat: 메타데이터 및 SEO 최적화

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html lang="en" class="relative h-full antialiased dark">
+<html lang="ko" class="relative h-full antialiased dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/favicon.png" />
+    <meta name="robots" content="index, follow" />
+    <meta name="googlebot" content="index, follow" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="theme-color" content="#18181b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     %sveltekit.head%
     <script>
       let darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,14 +2,36 @@
   import ArrowRightIcon from '$lib/components/ArrowRightIcon.svelte'
   import PostsList from '$lib/components/PostsList.svelte'
   import SocialLinks from '$lib/components/SocialLinks.svelte'
-  import { avatar, bio, name } from '$lib/info.js'
+  import { avatar, bio, name, website } from '$lib/info.js'
   /** @type {import('./$types').PageData} */
   export let data
+
+  const url = website
+  const title = `${name}'s life log`
 </script>
 
 <svelte:head>
-  <title>{name}'s life log</title>
+  <title>{title}</title>
   <meta name="description" content={bio} />
+  <meta name="author" content={name} />
+
+  <!-- 표준 메타 태그 -->
+  <link rel="canonical" href={url} />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content={url} />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={bio} />
+  <meta property="og:image" content={avatar} />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary" />
+  <meta property="twitter:domain" content={website} />
+  <meta property="twitter:url" content={url} />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={bio} />
+  <meta name="twitter:image" content={avatar} />
 </svelte:head>
 
 <div class="flex flex-col flex-grow gap-8 pb-16">

--- a/src/routes/posts/[[page]]/+page.server.js
+++ b/src/routes/posts/[[page]]/+page.server.js
@@ -1,4 +1,5 @@
-export const prerender = false
+// 특정 태그 조합으로는 정적 생성 가능하도록 함
+export const prerender = 'auto'
 
 import { posts } from '$lib/data/posts'
 import { paginate } from '$lib/util'

--- a/src/routes/posts/[[page]]/+page.svelte
+++ b/src/routes/posts/[[page]]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { detail, name, topic } from '$lib/info.js'
+  import { detail, name, topic, website, bio } from '$lib/info.js'
   import PostsList from '$lib/components/PostsList.svelte'
   import Pagination from '$lib/components/Pagination.svelte'
   import Tags from '$lib/components/Tags.svelte'
@@ -20,10 +20,39 @@
       goto(`/posts?tag=${tag}`)
     }
   }
+
+  // 현재 페이지 URL 생성
+  $: currentUrl = `${website}/posts${data.page > 1 ? '/' + data.page : ''}${data.tagFilter ? '?tag=' + data.tagFilter : ''}`
+
+  // 페이지 타이틀 생성
+  $: pageTitle = data.tagFilter
+    ? `${data.tagFilter} - ${name}'s life log | Posts`
+    : `${name}'s life log | Posts`
+
+  // 메타 설명 생성
+  $: metaDescription = data.tagFilter ? `${detail} - ${data.tagFilter} 관련 포스트 모음` : detail
 </script>
 
 <svelte:head>
-  <title>{name}'s life log | Posts</title>
+  <title>{pageTitle}</title>
+  <meta name="description" content={metaDescription} />
+  <meta name="author" content={name} />
+
+  <!-- 표준 메타 태그 -->
+  <link rel="canonical" href={currentUrl} />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content={currentUrl} />
+  <meta property="og:title" content={pageTitle} />
+  <meta property="og:description" content={metaDescription} />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary" />
+  <meta property="twitter:domain" content={website} />
+  <meta property="twitter:url" content={currentUrl} />
+  <meta name="twitter:title" content={pageTitle} />
+  <meta name="twitter:description" content={metaDescription} />
 </svelte:head>
 
 <div class="flex flex-col flex-grow">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Allow: /
+
+# Sitemap 위치 지정
+Sitemap: https://blog.nanggo.net/sitemap.xml


### PR DESCRIPTION
- HTML 문서의 언어를 한국어로 변경
- 페이지 메타데이터에 Open Graph 및 Twitter 카드 추가
- 포스트 페이지의 URL 및 메타 설명 동적 생성 로직 구현
- robots.txt 파일에 Sitemap 위치 지정 및 접근 허용 설정 추가
- prerender 설정을 'auto'로 변경하여 특정 태그 조합으로 정적 생성 가능하도록 개선