### PR TITLE
feat: 태그 클라우드 생성 로직을 클라이언트 사이드로 이동

### DIFF
--- a/src/routes/posts/[[page]]/+page.server.js
+++ b/src/routes/posts/[[page]]/+page.server.js
@@ -1,7 +1,7 @@
 // 특정 태그 조합으로는 정적 생성 가능하도록 함
 export const prerender = false
 
-import { posts } from '$lib/data/posts'
+import { allTags, posts } from '$lib/data/posts'
 import { paginate } from '$lib/util'
 import { error } from '@sveltejs/kit'
 
@@ -31,29 +31,6 @@ export async function load({ params, url }) {
 
   // 다음 페이지 존재 여부 계산 (필터링된 포스트 기준)
   const hasNextPage = page * limit < filteredPosts.length
-
-  // 모든 태그 수집 및 빈도 계산 - 한 번의 순회로 처리
-  const tagCounts = {}
-  const tagSet = new Set()
-
-  posts.forEach((post) => {
-    if (post.tags) {
-      post.tags.forEach((tag) => {
-        if (tag) {
-          tagSet.add(tag)
-          tagCounts[tag] = (tagCounts[tag] || 0) + 1
-        }
-      })
-    }
-  })
-
-  // 태그를 빈도순으로 정렬하고, 빈도가 같으면 알파벳순으로 정렬
-  let allTags = Array.from(tagSet).sort((a, b) => {
-    // 빈도 내림차순 정렬
-    const countDiff = tagCounts[b] - tagCounts[a]
-    // 빈도가 같으면 알파벳 오름차순 정렬
-    return countDiff !== 0 ? countDiff : a.localeCompare(b)
-  })
 
   return {
     posts: postsForPage,


### PR DESCRIPTION
태그 필터링 페이지에서 서버리스 함수 실행 시간을 줄여 Vercel 성능을 개선합니다.
- `src/routes/posts/[[page]]/+page.server.js`에서 태그 계산 로직 제거.
- `src/routes/posts/[[page]]/+page.server.js`에서 `allPosts`를 클라이언트로 전달.
- `src/routes/posts/[[page]]/+page.svelte`에서 `allPosts`를 사용하여 태그 계산 로직 구현.