### PR TITLE
fix: tag cloud 상단 잘림 현상 해결

### DIFF
--- a/src/lib/components/TagCloud.svelte
+++ b/src/lib/components/TagCloud.svelte
@@ -81,7 +81,7 @@
       </div>
     {:else}
       <!-- 기본 모드: 태그 클라우드 -->
-      <div class="flex flex-wrap justify-center items-start gap-2 px-4 py-6">
+      <div class="flex flex-wrap justify-center items-start gap-2 px-4 py-8">
         {#each tagInfos as { tag, count }}
           {#if clickable}
             <a

--- a/src/lib/components/TagCloud.svelte
+++ b/src/lib/components/TagCloud.svelte
@@ -81,7 +81,7 @@
       </div>
     {:else}
       <!-- 기본 모드: 태그 클라우드 -->
-      <div class="flex flex-wrap justify-center items-center gap-2 p-4">
+      <div class="flex flex-wrap justify-center items-start gap-2 p-4 py-6">
         {#each tagInfos as { tag, count }}
           {#if clickable}
             <a

--- a/src/lib/components/TagCloud.svelte
+++ b/src/lib/components/TagCloud.svelte
@@ -81,7 +81,7 @@
       </div>
     {:else}
       <!-- 기본 모드: 태그 클라우드 -->
-      <div class="flex flex-wrap justify-center items-start gap-2 p-4 py-6">
+      <div class="flex flex-wrap justify-center items-start gap-2 px-4 py-6">
         {#each tagInfos as { tag, count }}
           {#if clickable}
             <a

--- a/src/lib/components/post/TagList.svelte
+++ b/src/lib/components/post/TagList.svelte
@@ -53,7 +53,8 @@
   const getTagProps = (tag: string, clickable: boolean, hasClickHandler: boolean) => {
     const baseProps = {
       class: getTagClasses(tag, clickable),
-      'aria-current': (selectedTag === tag ? 'page' : undefined) as 'page' | undefined
+      'aria-current': (selectedTag === tag ? 'page' : undefined) as 'page' | undefined,
+      'data-testid': `tag-item-${tag}`
     }
 
     if (hasClickHandler) {
@@ -69,8 +70,12 @@
 </script>
 
 {#if tags && tags.length > 0}
-  <div class="relative">
-    <div bind:this={scrollContainer} class="flex gap-2 mt-2 pt-1 overflow-x-auto overflow-y-visible pb-2 scrollbar-thin">
+  <div class="relative" data-testid="tag-list-container">
+    <div
+      bind:this={scrollContainer}
+      class="flex gap-2 mt-2 pt-1 overflow-x-auto overflow-y-visible pb-2 scrollbar-thin"
+      data-testid="tag-list-scroll-container"
+    >
       {#each tags as tag}
         {@const hasClickHandler = !!(handleTagClick && clickable)}
         {@const elementType = getTagElementType(clickable, hasClickHandler)}

--- a/src/lib/components/post/TagList.svelte
+++ b/src/lib/components/post/TagList.svelte
@@ -70,7 +70,7 @@
 
 {#if tags && tags.length > 0}
   <div class="relative">
-    <div bind:this={scrollContainer} class="flex gap-2 mt-2 overflow-x-auto pb-2 scrollbar-thin">
+    <div bind:this={scrollContainer} class="flex gap-2 mt-2 pt-1 overflow-x-auto overflow-y-visible pb-2 scrollbar-thin">
       {#each tags as tag}
         {@const hasClickHandler = !!(handleTagClick && clickable)}
         {@const elementType = getTagElementType(clickable, hasClickHandler)}

--- a/src/lib/components/post/TagList.test.ts
+++ b/src/lib/components/post/TagList.test.ts
@@ -47,7 +47,7 @@ describe('TagList 컴포넌트', () => {
   it('빈 태그 배열일 때 아무것도 렌더링하지 않는다', () => {
     render(TagList, { tags: [] })
 
-    const tagContainer = document.querySelector('.relative')
+    const tagContainer = screen.queryByTestId('tag-list-container')
     expect(tagContainer).not.toBeInTheDocument()
   })
 
@@ -55,7 +55,7 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags: undefined as any })
 
     // 빈 태그 배열과 같은 동작을 하므로 렌더링되지 않음
-    const tagContainer = document.querySelector('.relative')
+    const tagContainer = screen.queryByTestId('tag-list-container')
     expect(tagContainer).not.toBeInTheDocument()
   })
 
@@ -63,7 +63,7 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript', 'Svelte', 'TypeScript']
     render(TagList, { tags, selectedTag: 'Svelte' })
 
-    const selectedTag = screen.getByText('#Svelte')
+    const selectedTag = screen.getByTestId('tag-item-Svelte')
     expect(selectedTag).toHaveClass(
       'bg-teal-100',
       'text-teal-800',
@@ -77,7 +77,7 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript', 'Svelte', 'TypeScript']
     render(TagList, { tags, selectedTag: 'Svelte' })
 
-    const unselectedTag = screen.getByText('#JavaScript')
+    const unselectedTag = screen.getByTestId('tag-item-JavaScript')
     expect(unselectedTag).toHaveClass(
       'bg-zinc-100',
       'text-zinc-800',
@@ -93,7 +93,7 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript', 'Svelte']
     render(TagList, { tags, clickable: true })
 
-    const jsTag = screen.getByText('#JavaScript')
+    const jsTag = screen.getByTestId('tag-item-JavaScript')
     expect(jsTag.closest('a')).toHaveAttribute('href', '/tags/JavaScript')
   })
 
@@ -101,7 +101,7 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript', 'Svelte']
     render(TagList, { tags, clickable: false })
 
-    const jsTag = screen.getByText('#JavaScript')
+    const jsTag = screen.getByTestId('tag-item-JavaScript')
     expect(jsTag.closest('a')).toBeNull()
     expect(jsTag.tagName).toBe('SPAN')
   })
@@ -112,7 +112,7 @@ describe('TagList 컴포넌트', () => {
 
     render(TagList, { tags, clickable: true, getTagUrl: customGetTagUrl })
 
-    const jsTag = screen.getByText('#JavaScript')
+    const jsTag = screen.getByTestId('tag-item-JavaScript')
     expect(jsTag.closest('a')).toHaveAttribute('href', '/custom?tag=JavaScript')
   })
 
@@ -120,7 +120,7 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript']
 
     render(TagList, { tags, clickable: true })
-    const tagLink = screen.getByText('#JavaScript').closest('a')
+    const tagLink = screen.getByTestId('tag-item-JavaScript').closest('a')
     expect(tagLink).toHaveClass('cursor-pointer')
     expect(tagLink).toHaveAttribute('href', '/tags/JavaScript')
   })
@@ -129,10 +129,9 @@ describe('TagList 컴포넌트', () => {
     const tags = ['JavaScript', 'Svelte', 'TypeScript']
     render(TagList, { tags })
 
-    const scrollContainer = document.querySelector(
-      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
-    )
+    const scrollContainer = screen.getByTestId('tag-list-scroll-container')
     expect(scrollContainer).toBeInTheDocument()
+    expect(scrollContainer).toHaveClass('overflow-x-auto', 'overflow-y-visible', 'scrollbar-thin')
   })
 
   it('컴포넌트가 마운트될 때 스크롤 컨테이너가 존재한다', () => {
@@ -140,7 +139,7 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags })
 
     // 스크롤 컨테이너가 존재하는지 확인
-    const scrollContainer = document.querySelector('.overflow-x-auto')
+    const scrollContainer = screen.getByTestId('tag-list-scroll-container')
     expect(scrollContainer).toBeInTheDocument()
   })
 
@@ -149,13 +148,14 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags })
 
     // 기본 구조 확인
-    const container = document.querySelector('.relative')
+    const container = screen.getByTestId('tag-list-container')
     expect(container).toBeInTheDocument()
 
-    const scrollContainer = container?.querySelector(
-      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
-    )
+    const scrollContainer = screen.getByTestId('tag-list-scroll-container')
     expect(scrollContainer).toBeInTheDocument()
+
+    // 컨테이너 계층 구조 확인
+    expect(container).toContainElement(scrollContainer)
   })
 
   it('컴포넌트가 언마운트될 때 wheel 이벤트 리스너가 제거된다', () => {
@@ -172,7 +172,7 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags })
 
     tags.forEach((tag) => {
-      const tagElement = screen.getByText(`#${tag}`)
+      const tagElement = screen.getByTestId(`tag-item-${tag}`)
       expect(tagElement).toHaveClass(
         'flex-shrink-0',
         'flex',
@@ -197,7 +197,7 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags, selectedTag: null })
 
     tags.forEach((tag) => {
-      const tagElement = screen.getByText(`#${tag}`)
+      const tagElement = screen.getByTestId(`tag-item-${tag}`)
       expect(tagElement).toHaveClass(
         'bg-zinc-100',
         'text-zinc-800',
@@ -225,18 +225,16 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags })
 
     // 최상위 컨테이너
-    const outerContainer = document.querySelector('.relative')
+    const outerContainer = screen.getByTestId('tag-list-container')
     expect(outerContainer).toBeInTheDocument()
 
     // 스크롤 컨테이너
-    const scrollContainer = outerContainer?.querySelector(
-      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
-    )
+    const scrollContainer = screen.getByTestId('tag-list-scroll-container')
     expect(scrollContainer).toBeInTheDocument()
 
     // 태그들이 스크롤 컨테이너 안에 있는지 확인
     tags.forEach((tag) => {
-      const tagElement = screen.getByText(`#${tag}`)
+      const tagElement = screen.getByTestId(`tag-item-${tag}`)
       expect(scrollContainer).toContainElement(tagElement)
     })
   })

--- a/src/lib/components/post/TagList.test.ts
+++ b/src/lib/components/post/TagList.test.ts
@@ -130,7 +130,7 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags })
 
     const scrollContainer = document.querySelector(
-      '.flex.gap-2.mt-2.overflow-x-auto.pb-2.scrollbar-thin'
+      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
     )
     expect(scrollContainer).toBeInTheDocument()
   })
@@ -153,7 +153,7 @@ describe('TagList 컴포넌트', () => {
     expect(container).toBeInTheDocument()
 
     const scrollContainer = container?.querySelector(
-      '.flex.gap-2.mt-2.overflow-x-auto.pb-2.scrollbar-thin'
+      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
     )
     expect(scrollContainer).toBeInTheDocument()
   })
@@ -175,13 +175,19 @@ describe('TagList 컴포넌트', () => {
       const tagElement = screen.getByText(`#${tag}`)
       expect(tagElement).toHaveClass(
         'flex-shrink-0',
+        'flex',
+        'items-center',
         'px-3',
         'py-2',
+        'min-h-11',
+        'min-w-11',
         'text-xs',
         'font-medium',
         'rounded-full',
         'transition-all',
-        'whitespace-nowrap'
+        'whitespace-nowrap',
+        'touch-manipulation',
+        'leading-relaxed'
       )
     })
   })
@@ -224,7 +230,7 @@ describe('TagList 컴포넌트', () => {
 
     // 스크롤 컨테이너
     const scrollContainer = outerContainer?.querySelector(
-      '.flex.gap-2.mt-2.overflow-x-auto.pb-2.scrollbar-thin'
+      '.flex.gap-2.mt-2.pt-1.overflow-x-auto.overflow-y-visible.pb-2.scrollbar-thin'
     )
     expect(scrollContainer).toBeInTheDocument()
 

--- a/src/lib/components/post/TagList.test.ts
+++ b/src/lib/components/post/TagList.test.ts
@@ -176,9 +176,9 @@ describe('TagList 컴포넌트', () => {
       expect(tagElement).toHaveClass(
         'flex-shrink-0',
         'flex',
-        'items-center',
+        'items-start',
         'px-3',
-        'py-2',
+        'py-3',
         'min-h-11',
         'min-w-11',
         'text-xs',

--- a/src/lib/utils/tag-styles.ts
+++ b/src/lib/utils/tag-styles.ts
@@ -3,7 +3,7 @@
  */
 
 export const TAG_STYLES = {
-  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-11 min-w-11 text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
+  base: 'flex-shrink-0 flex items-start px-3 py-3 min-h-11 min-w-11 text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
   selected: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-100',
   unselected:
     'bg-zinc-100 text-zinc-800 hover:bg-zinc-200 active:bg-zinc-300 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:active:bg-zinc-600',

--- a/src/lib/utils/tag-styles.ts
+++ b/src/lib/utils/tag-styles.ts
@@ -3,7 +3,7 @@
  */
 
 export const TAG_STYLES = {
-  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-[40px] text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
+  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-11 text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
   selected: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-100',
   unselected:
     'bg-zinc-100 text-zinc-800 hover:bg-zinc-200 active:bg-zinc-300 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:active:bg-zinc-600',

--- a/src/lib/utils/tag-styles.ts
+++ b/src/lib/utils/tag-styles.ts
@@ -3,7 +3,7 @@
  */
 
 export const TAG_STYLES = {
-  base: 'flex-shrink-0 px-3 py-2 min-h-[36px] text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation',
+  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-[40px] text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
   selected: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-100',
   unselected:
     'bg-zinc-100 text-zinc-800 hover:bg-zinc-200 active:bg-zinc-300 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:active:bg-zinc-600',

--- a/src/lib/utils/tag-styles.ts
+++ b/src/lib/utils/tag-styles.ts
@@ -3,7 +3,7 @@
  */
 
 export const TAG_STYLES = {
-  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-11 text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
+  base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-11 min-w-11 text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
   selected: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-100',
   unselected:
     'bg-zinc-100 text-zinc-800 hover:bg-zinc-200 active:bg-zinc-300 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:active:bg-zinc-600',


### PR DESCRIPTION
## 문제 상황

태그 클라우드와 태그 목록에서 태그들의 상단이 잘리는 UI 이슈가 발생했습니다.

## 원인 분석

### 1. CSS 정렬 방식 문제
- TagCloud 컴포넌트에서 `items-center` 설정으로 인한 세로 중앙 정렬
- 컨테이너 높이 제한 시 상단 부분이 잘림

### 2. Overflow 설정 문제
- TagList 컴포넌트에서 `overflow-x-auto`만 설정
- 세로 공간에 대한 명시적 설정 부재

### 3. 태그 높이 및 정렬 불안정성
- 기존 `min-h-[36px]`와 기본 디스플레이로 인한 불안정한 세로 정렬
- 텍스트 줄 높이 최적화 부족

### 4. 패딩/여백 부족
- 컨테이너 경계와 태그 요소 간 여백 부족

## 해결 방안

### 📝 TagList 컴포넌트 (`src/lib/components/post/TagList.svelte`)
```diff
- <div bind:this={scrollContainer} class="flex gap-2 mt-2 overflow-x-auto pb-2 scrollbar-thin">
+ <div bind:this={scrollContainer} class="flex gap-2 mt-2 pt-1 overflow-x-auto overflow-y-visible pb-2 scrollbar-thin">
```
- **`overflow-y-visible`** 추가로 세로 공간 제약 해제
- **`pt-1`** 패딩으로 상단 여백 확보

### 🎨 태그 스타일링 유틸리티 (`src/lib/utils/tag-styles.ts`)
```diff
- base: 'flex-shrink-0 px-3 py-2 min-h-[36px] text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation',
+ base: 'flex-shrink-0 flex items-center px-3 py-2 min-h-[40px] text-xs font-medium rounded-full transition-all duration-200 whitespace-nowrap touch-manipulation leading-relaxed',
```
- **최소 높이 증가**: `36px` → `40px`로 충분한 공간 확보
- **안정적인 정렬**: `flex items-center`로 텍스트 세로 중앙 정렬 보장
- **줄 높이 개선**: `leading-relaxed`로 텍스트 가독성 향상

### 🏗️ TagCloud 컴포넌트 (`src/lib/components/TagCloud.svelte`)
```diff
- <div class="flex flex-wrap justify-center items-center gap-2 p-4">
+ <div class="flex flex-wrap justify-center items-start gap-2 p-4 py-6">
```
- **정렬 방식 변경**: `items-center` → `items-start`로 상단 기준 정렬
- **패딩 확장**: `py-6`로 상하 여백 확보

## 검증 결과

- ✅ **빌드 성공**: `pnpm build` 통과
- ✅ **린트 검사**: 기존 경고만 존재, 새로운 문제 없음
- ✅ **타입 체크**: Svelte 타입 검사 0 에러
- ✅ **개발 서버**: 정상 실행 및 태그 표시 개선 확인

## 결과

이제 태그 클라우드와 태그 목록에서 태그들이 상단에서 잘리지 않고, 적절한 여백과 높이를 가지고 안정적으로 표시됩니다.