### PR TITLE
fix: about 페이지 가로 스크롤 문제 해결

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -67,7 +67,7 @@
   </script>
 </svelte:head>
 
-<main class="about max-w-2xl mx-auto lg:max-w-none">
+<main class="about max-w-2xl mx-auto lg:max-w-none overflow-x-hidden">
   <div class="hidden lg:block pt-8">
     <div class="sticky top-0 w-full flex justify-end pt-11 pr-8"></div>
   </div>
@@ -142,7 +142,7 @@
     position: absolute;
     display: inline-block;
     top: 0;
-    right: -14px;
+    right: -10px;
     width: 10px;
     height: 10px;
     border-radius: 50%;
@@ -152,6 +152,7 @@
 
   @media (min-width: 640px) {
     :global(.about h2::after) {
+      right: -12px;
       width: 12px;
       height: 12px;
     }
@@ -193,7 +194,26 @@
   :global(.about table) {
     margin-top: 15px;
     margin-bottom: 13px;
+    width: 100%;
+    word-break: break-word;
+    overflow-wrap: break-word;
     /* Remove custom styling to use global prose table styles with mobile optimization */
+  }
+
+  :global(.about table td) {
+    max-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media (max-width: 640px) {
+    :global(.about table) {
+      font-size: 0.9em;
+    }
+
+    :global(.about table td) {
+      padding: 0.25rem 0.5rem;
+    }
   }
 
   :global(.about code) {


### PR DESCRIPTION
## Summary
- about 페이지에서 특정 해상도에서 발생하던 가로 스크롤 문제를 해결했습니다
- 테이블과 h2 요소의 스타일링을 개선하여 모든 해상도에서 적절히 표시되도록 수정했습니다

## Changes
### 1. 컨테이너 오버플로우 제어
- 메인 컨테이너에 `overflow-x-hidden` 추가하여 가로 스크롤 방지

### 2. 테이블 반응형 스타일링 개선
- `word-break: break-word` 및 `overflow-wrap: break-word` 추가
- `text-overflow: ellipsis`로 긴 텍스트 처리
- 모바일 해상도에서 폰트 크기(0.9em) 및 패딩(0.25rem 0.5rem) 최적화

### 3. h2 요소 ::after 의사 요소 위치 조정
- `right` 값을 `-14px`에서 `-10px`로 조정 (모바일)
- 데스크톱에서는 `-12px`로 조정
- 화면 가장자리에서 요소가 넘치지 않도록 안전한 값으로 변경

## Test Results
- ✅ Build 성공: `pnpm build`
- ✅ Lint 통과: `pnpm lint`
- ✅ Type Check 성공: `pnpm check`
- ✅ 다양한 해상도에서 가로 스크롤 없음 확인

## Screenshots
다양한 해상도에서 테스트 완료했으며, 가로 스크롤이 발생하지 않음을 확인했습니다.

## Related Issues
- 특정 해상도에서 about 페이지에 가로 스크롤이 발생하는 UI 문제 해결