### PR TITLE
fix(seo): align indexability and sitemap metadata

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.png" />
-    <meta name="robots" content="index, follow, max-image-preview:large" />
-    <meta name="googlebot" content="index, follow" />
     <meta name="naver-site-verification" content="770124667ed0f9d43f7c238ff280159c23a1e320" />
     <meta name="format-detection" content="telephone=no" />
     %sveltekit.head%

--- a/src/lib/utils/seo.test.ts
+++ b/src/lib/utils/seo.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { MIN_INDEXABLE_TAG_POSTS, isTagIndexable } from './seo'
+
+describe('tag indexability', () => {
+  it('indexes tags at or above the shared post threshold', () => {
+    expect(isTagIndexable(MIN_INDEXABLE_TAG_POSTS - 1)).toBe(false)
+    expect(isTagIndexable(MIN_INDEXABLE_TAG_POSTS)).toBe(true)
+    expect(isTagIndexable(MIN_INDEXABLE_TAG_POSTS + 1)).toBe(true)
+  })
+
+  it('rejects invalid counts', () => {
+    expect(isTagIndexable(Number.NaN)).toBe(false)
+    expect(isTagIndexable(2.5)).toBe(false)
+  })
+})

--- a/src/lib/utils/seo.ts
+++ b/src/lib/utils/seo.ts
@@ -1,0 +1,5 @@
+export const MIN_INDEXABLE_TAG_POSTS = 2
+
+export function isTagIndexable(postCount: number): boolean {
+  return Number.isInteger(postCount) && postCount >= MIN_INDEXABLE_TAG_POSTS
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,6 +38,8 @@
 
   // 페이지가 자체 seo.description을 내려주면 우선 사용 (예: 포스트 목록 페이지네이션)
   $: metaDescription = $page.data.seo?.description ?? description
+  $: metaTitle = $page.data.seo?.title ?? data.title
+  $: robots = $page.data.seo?.robots ?? 'index, follow, max-image-preview:large'
 
   const _organizationSchema = {
     '@context': 'https://schema.org',
@@ -253,7 +255,8 @@
 </script>
 
 <svelte:head>
-  <title>{data.title}</title>
+  <title>{metaTitle}</title>
+  <meta name="robots" content={robots} />
   {#if !$page.data.post && !$page.route.id?.includes('/about') && !$page.route.id?.startsWith('/tags') && !$page.route.id?.startsWith('/posts/category')}
     <meta name="description" content={metaDescription} />
   {/if}
@@ -274,7 +277,7 @@
   {#if !$page.data.post && !$page.route.id?.includes('/about') && !$page.route.id?.startsWith('/tags') && !$page.route.id?.startsWith('/posts/category')}
     <meta property="og:type" content="website" />
     <meta property="og:url" content={new URL($page.url.pathname, website).href} />
-    <meta property="og:title" content={data.title} />
+    <meta property="og:title" content={metaTitle} />
     <meta property="og:description" content={metaDescription} />
     <meta property="og:image" content={defaultOgImage} />
     <meta property="og:image:width" content="1200" />
@@ -287,7 +290,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content={twitterHandle} />
     <meta name="twitter:creator" content={twitterHandle} />
-    <meta name="twitter:title" content={data.title} />
+    <meta name="twitter:title" content={metaTitle} />
     <meta name="twitter:description" content={metaDescription} />
     <meta name="twitter:image" content={defaultOgImage} />
     <meta name="twitter:image:alt" content={`${name} 로고`} />

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,14 @@
 import type { PageServerLoad } from './$types'
 
 import { posts, getCategoryInfos } from '$lib/data/posts'
+import { name } from '$lib/info'
 
 export const load: PageServerLoad = async () => {
   return {
     posts: posts.slice(0, 5),
-    categoryInfos: getCategoryInfos()
+    categoryInfos: getCategoryInfos(),
+    seo: {
+      title: `${name} - 흔한 개발자의 일상과 기술 블로그`
+    }
   }
 }

--- a/src/routes/posts/[[page]]/+page.server.js
+++ b/src/routes/posts/[[page]]/+page.server.js
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit'
 
 import { posts as allPosts } from '$lib/data/posts'
-import { description } from '$lib/info'
+import { description, name } from '$lib/info'
 import { extractPostMetadata } from '$lib/util'
 
 // Statically generate all post list pages
@@ -26,6 +26,7 @@ export async function load({ params }) {
 
   // 목록 페이지에 필요한 메타데이터만 포함
   const posts = extractPostMetadata(paginatedPosts)
+  const title = `${name}'s life log | Posts${page > 1 ? ` - ${page}페이지` : ''}`
 
   return {
     page,
@@ -33,7 +34,10 @@ export async function load({ params }) {
     totalPosts,
     totalPages,
     posts,
-    // 페이지네이션 페이지는 중복 메타를 피하기 위해 페이지 번호가 들어간 설명 사용
-    seo: page > 1 ? { description: `${description} (${page}페이지)` } : undefined
+    seo: {
+      title,
+      // 페이지네이션 페이지는 중복 메타를 피하기 위해 페이지 번호가 들어간 설명 사용
+      description: page > 1 ? `${description} (${page}페이지)` : description
+    }
   }
 }

--- a/src/routes/posts/category/[name]/[[page]]/+page.server.ts
+++ b/src/routes/posts/category/[name]/[[page]]/+page.server.ts
@@ -53,7 +53,10 @@ export async function load({ params }) {
     totalPages,
     seo: {
       title: `${validCategory} 포스트${page > 1 ? ` - ${page}페이지` : ''}`,
-      description: `${validCategory} 카테고리의 포스트를 확인하세요. 총 ${totalPosts}개의 포스트가 있습니다.`
+      description:
+        page > 1
+          ? `NANGGO's LIFELOG의 ${validCategory} 카테고리 ${page}페이지입니다. 전체 ${totalPosts}개의 글에서 관련 경험과 생각, 실무 기록을 이어서 살펴보세요.`
+          : `NANGGO's LIFELOG의 ${validCategory} 카테고리입니다. ${totalPosts}개의 글에서 관련 경험과 생각, 실무 기록을 한곳에서 살펴보세요.`
     }
   }
 }

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -14,6 +14,7 @@ import {
 import { website } from '$lib/info'
 import { generateCacheHeaders } from '$lib/utils/cache'
 import { createSafeSlug } from '$lib/utils/posts'
+import { isTagIndexable } from '$lib/utils/seo'
 
 export const prerender = true
 
@@ -54,20 +55,28 @@ const toAbsoluteImageUrl = (imageUrl, slug) => {
   return publicImageUrl.startsWith('http') ? publicImageUrl : `${website}${publicImageUrl}`
 }
 
-/**
- * 유효한 날짜를 ISO 문자열로 변환하는 안전한 함수
- * @param {string|Date} dateValue - 변환할 날짜 값
- * @returns {string} - ISO 형식의 날짜 문자열
- */
-const safeToISOString = (dateValue) => {
-  try {
-    const date = new Date(dateValue)
-    // Date 객체의 valueOf()가 NaN이면 유효하지 않은 날짜
-    return !isNaN(date.valueOf()) ? date.toISOString() : new Date().toISOString() // 유효하지 않은 경우 현재 날짜 사용
-  } catch (_e) {
-    return new Date().toISOString() // 예외 발생 시 현재 날짜 사용
-  }
+const toValidTimestamp = (dateValue) => {
+  if (!dateValue) return null
+
+  const timestamp = new Date(dateValue).valueOf()
+  return Number.isNaN(timestamp) ? null : timestamp
 }
+
+const toValidISOString = (dateValue) => {
+  const timestamp = toValidTimestamp(dateValue)
+  return timestamp === null ? null : new Date(timestamp).toISOString()
+}
+
+const getLatestModifiedIso = (items) => {
+  const latestTimestamp = items.reduce((latest, item) => {
+    const timestamp = toValidTimestamp(item.updated || item.date)
+    return timestamp !== null && (latest === null || timestamp > latest) ? timestamp : latest
+  }, null)
+
+  return latestTimestamp === null ? null : new Date(latestTimestamp).toISOString()
+}
+
+const renderLastmod = (isoDate) => (isoDate ? `<lastmod>${isoDate}</lastmod>` : '')
 
 /**
  * 포스트에서 첫 번째 이미지 정보를 추출하는 함수
@@ -116,6 +125,7 @@ const extractFirstImage = (post) => {
  */
 export async function GET({ setHeaders }) {
   const { etag, lastModified } = generateCacheHeaders(posts)
+  const latestPostModified = getLatestModifiedIso(posts)
 
   setHeaders({
     'Cache-Control': `max-age=0, s-max-age=3600`, // 1시간 캐시로 증가
@@ -137,8 +147,8 @@ export async function GET({ setHeaders }) {
       xmlns:xhtml="http://www.w3.org/1999/xhtml"
     >
       <url>
-        <loc>${website}</loc>
-        <lastmod>${safeToISOString(posts[0]?.date || new Date())}</lastmod>
+        <loc>${website}/</loc>
+        ${renderLastmod(latestPostModified)}
         <changefreq>daily</changefreq>
         <priority>1.0</priority>
       </url>
@@ -149,9 +159,15 @@ export async function GET({ setHeaders }) {
       </url>
       <url>
         <loc>${website}/posts</loc>
-        <lastmod>${safeToISOString(posts[0]?.date || new Date())}</lastmod>
+        ${renderLastmod(latestPostModified)}
         <changefreq>daily</changefreq>
         <priority>0.9</priority>
+      </url>
+      <url>
+        <loc>${website}/tags</loc>
+        ${renderLastmod(latestPostModified)}
+        <changefreq>weekly</changefreq>
+        <priority>0.7</priority>
       </url>
 
       ${(() => {
@@ -161,7 +177,7 @@ export async function GET({ setHeaders }) {
         for (let p = 2; p <= totalPages; p++) {
           pages.push(`<url>
             <loc>${website}/posts/${p}</loc>
-            <lastmod>${safeToISOString(posts[0]?.date || new Date())}</lastmod>
+            ${renderLastmod(latestPostModified)}
             <changefreq>daily</changefreq>
             <priority>0.6</priority>
           </url>`)
@@ -183,7 +199,7 @@ export async function GET({ setHeaders }) {
 
           return `<url>
             <loc>${getPostUrl(post.slug)}</loc>
-            <lastmod>${safeToISOString(post.updated || post.date)}</lastmod>
+            ${renderLastmod(toValidISOString(post.updated || post.date))}
             <changefreq>weekly</changefreq>
             <priority>0.7</priority>${imageXml}
           </url>`
@@ -196,14 +212,11 @@ export async function GET({ setHeaders }) {
           return categories
             .map((info) => {
               const catPosts = getPostsByCategory(info.category)
-              const latest = catPosts && catPosts.length > 0 ? catPosts[0] : null
-              const lastmod = latest
-                ? safeToISOString(latest.updated || latest.date)
-                : safeToISOString(new Date())
+              const lastmod = getLatestModifiedIso(catPosts || [])
               const urls = [
                 `<url>
                 <loc>${getCategoryUrl(info.category)}</loc>
-                <lastmod>${lastmod}</lastmod>
+                ${renderLastmod(lastmod)}
                 <changefreq>weekly</changefreq>
                 <priority>0.6</priority>
               </url>`
@@ -213,7 +226,7 @@ export async function GET({ setHeaders }) {
               for (let p = 2; p <= catTotalPages; p++) {
                 urls.push(`<url>
                 <loc>${getCategoryUrl(info.category)}/${p}</loc>
-                <lastmod>${lastmod}</lastmod>
+                ${renderLastmod(lastmod)}
                 <changefreq>weekly</changefreq>
                 <priority>0.5</priority>
               </url>`)
@@ -230,15 +243,13 @@ export async function GET({ setHeaders }) {
         try {
           const tags = getAllTagsWithCounts()
           return tags
+            .filter(({ count }) => isTagIndexable(count))
             .map(({ tag }) => {
               const tagPosts = getPostsByTag(tag)
-              const latest = tagPosts && tagPosts.length > 0 ? tagPosts[0] : null
-              const lastmod = latest
-                ? safeToISOString(latest.updated || latest.date)
-                : safeToISOString(new Date())
+              const lastmod = getLatestModifiedIso(tagPosts || [])
               return `<url>
                 <loc>${getTagUrl(tag)}</loc>
-                <lastmod>${lastmod}</lastmod>
+                ${renderLastmod(lastmod)}
                 <changefreq>weekly</changefreq>
                 <priority>0.5</priority>
               </url>`

--- a/src/routes/tags/+page.server.ts
+++ b/src/routes/tags/+page.server.ts
@@ -55,7 +55,7 @@ export async function load() {
     statistics,
     seo: {
       title: '모든 태그',
-      description: `블로그의 모든 태그를 확인하세요. 총 ${tagInfos.length}개의 태그가 있습니다.`
+      description: `NANGGO's LIFELOG에서 주제별 글을 빠르게 탐색할 수 있는 태그 모음입니다. 총 ${tagInfos.length}개의 태그를 확인해 보세요.`
     }
   }
 }

--- a/src/routes/tags/[tag]/+page.server.ts
+++ b/src/routes/tags/[tag]/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from './$types'
 
 import { getPostsByTag, getAllTagsWithCounts } from '$lib/data/posts'
 import { extractPostMetadata } from '$lib/util'
+import { isTagIndexable } from '$lib/utils/seo'
 
 export const prerender = true
 
@@ -31,6 +32,7 @@ export const load: PageServerLoad = async ({ params }) => {
   // Get tag info for count
   const tagInfo = allTagInfos.find((info) => info.tag === tagName)
   const postCount = tagInfo?.count || 0
+  const indexable = isTagIndexable(postCount)
 
   return {
     tagName,
@@ -38,7 +40,9 @@ export const load: PageServerLoad = async ({ params }) => {
     postCount,
     seo: {
       title: `${tagName} 태그`,
-      description: `'${tagName}' 태그가 포함된 ${postCount}개의 포스트를 확인하세요.`
+      description: `NANGGO's LIFELOG에서 '${tagName}' 태그로 분류된 ${postCount}개의 글을 모았습니다. 관련 개발 경험과 생각, 실무 기록을 살펴보세요.`,
+      indexable,
+      robots: `${indexable ? 'index' : 'noindex'}, follow, max-image-preview:large`
     }
   }
 }


### PR DESCRIPTION
## Summary

- centralize per-route title and robots metadata in the root layout
- mark one-post tag archives as `noindex, follow` and omit them from the sitemap
- add the tags index and paginated archives to the sitemap where appropriate
- derive `lastmod` from the latest valid post `updated`/`date` value instead of falling back to the current time
- improve unique titles and descriptions for list, category, and tag pages

## Validation

- `pnpm test:run -- src/lib/utils/seo.test.ts` (17 files, 221 tests passed)
- `pnpm check` (0 errors, 0 warnings)
- `pnpm seo:validate` (41/41 pages valid, 0 errors; existing 2 warnings)
- `git diff --check`