### PR TITLE
feat: add post navigation and complete breadcrumbs

### DIFF
--- a/src/lib/components/layout/Breadcrumb.svelte
+++ b/src/lib/components/layout/Breadcrumb.svelte
@@ -9,9 +9,9 @@
 </script>
 
 <nav aria-label="Breadcrumb">
-  <ol class="flex items-center space-x-2 text-sm text-zinc-600 dark:text-zinc-400">
+  <ol class="flex flex-wrap items-center gap-y-2 text-sm text-zinc-600 dark:text-zinc-400">
     {#each processedItems as item, index}
-      <li class="flex items-center">
+      <li class="flex min-w-0 max-w-full items-center">
         {#if index > 0}
           <!-- Separator -->
           <svg
@@ -31,7 +31,7 @@
         {#if item.current || !item.href}
           <!-- Current page or non-linked item -->
           <span
-            class="text-zinc-900 dark:text-zinc-100 font-medium"
+            class="break-words text-zinc-900 dark:text-zinc-100 font-medium"
             aria-current={item.current ? 'page' : undefined}
           >
             {item.label}
@@ -40,7 +40,7 @@
           <!-- Linked item -->
           <a
             href={item.href}
-            class="hover:text-zinc-900 dark:hover:text-zinc-200 transition-colors focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-800 rounded-sm"
+            class="break-words hover:text-zinc-900 dark:hover:text-zinc-200 transition-colors focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-800 rounded-sm"
             aria-label={`Go to ${item.label}`}
           >
             {item.label}

--- a/src/routes/post/[slug]/+page.server.ts
+++ b/src/routes/post/[slug]/+page.server.ts
@@ -141,7 +141,9 @@ export const load: PageServerLoad = async ({ params }) => {
       timeRequired: `PT${post.readingTime}M`
     }
 
-    // Simplified breadcrumb for better performance
+    const categoryUrl = `${website}/posts/category/${encodeURIComponent(post.category)}`
+
+    // Keep the structured breadcrumb aligned with the visible navigation.
     const breadcrumbLd = {
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
@@ -149,12 +151,24 @@ export const load: PageServerLoad = async ({ params }) => {
         {
           '@type': 'ListItem',
           position: 1,
-          name: 'Posts',
-          item: `${website}/posts`
+          name: '홈',
+          item: `${website}/`
         },
         {
           '@type': 'ListItem',
           position: 2,
+          name: '포스트',
+          item: `${website}/posts`
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: post.category,
+          item: categoryUrl
+        },
+        {
+          '@type': 'ListItem',
+          position: 4,
           name: post.title,
           item: url
         }

--- a/src/routes/post/[slug]/+page.svelte
+++ b/src/routes/post/[slug]/+page.svelte
@@ -64,13 +64,16 @@
 
   // Breadcrumb items for post page
   $: breadcrumbItems = [
+    { label: '홈', href: '/' },
     { label: '포스트', href: '/posts' },
     {
       label: data.post.category,
-      href: `/posts/category/${encodeURIComponent(data.post.category)}`,
-      current: true
-    }
+      href: `/posts/category/${encodeURIComponent(data.post.category)}`
+    },
+    { label: data.post.title, current: true }
   ]
+
+  const getPostUrl = (slug: string): string => `/post/${encodeURIComponent(slug)}`
 </script>
 
 <svelte:head>
@@ -169,6 +172,44 @@
         <svelte:component this={data.component} />
       </div>
     </article>
+
+    {#if data.post.previous || data.post.next}
+      <nav class="grid grid-cols-1 gap-4 py-8 sm:grid-cols-2" aria-label="포스트 탐색">
+        {#if data.post.previous}
+          <a
+            href={getPostUrl(data.post.previous.slug)}
+            rel="prev"
+            aria-label={`이전 글: ${data.post.previous.title}`}
+            class="group rounded-lg border border-zinc-200 p-4 transition-colors hover:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:border-zinc-700 dark:hover:border-teal-400 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-zinc-900"
+            data-sveltekit-preload-data="viewport"
+          >
+            <span class="block text-sm text-zinc-500 dark:text-zinc-400">← 이전 글</span>
+            <span
+              class="mt-1 block font-medium text-zinc-800 group-hover:text-teal-600 dark:text-zinc-100 dark:group-hover:text-teal-400"
+            >
+              {data.post.previous.title}
+            </span>
+          </a>
+        {/if}
+
+        {#if data.post.next}
+          <a
+            href={getPostUrl(data.post.next.slug)}
+            rel="next"
+            aria-label={`다음 글: ${data.post.next.title}`}
+            class="group rounded-lg border border-zinc-200 p-4 text-right transition-colors hover:border-teal-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:border-zinc-700 dark:hover:border-teal-400 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-zinc-900 sm:col-start-2"
+            data-sveltekit-preload-data="viewport"
+          >
+            <span class="block text-sm text-zinc-500 dark:text-zinc-400">다음 글 →</span>
+            <span
+              class="mt-1 block font-medium text-zinc-800 group-hover:text-teal-600 dark:text-zinc-100 dark:group-hover:text-teal-400"
+            >
+              {data.post.next.title}
+            </span>
+          </a>
+        {/if}
+      </nav>
+    {/if}
 
     <!-- bio -->
     <hr />

--- a/src/routes/post/[slug]/Page.test.ts
+++ b/src/routes/post/[slug]/Page.test.ts
@@ -1,0 +1,72 @@
+// Route-level accessibility and navigation tests for the rendered post page.
+import { render, screen, within } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('$app/navigation', () => ({
+  afterNavigate: vi.fn()
+}))
+
+import Page from './+page.svelte'
+
+import SocialLinks from '$lib/components/layout/SocialLinks.svelte'
+
+const data = {
+  post: {
+    slug: 'current-post',
+    title: '현재 글',
+    description: '현재 글 설명',
+    date: '2026-07-10',
+    displayDate: '2026년 7월 10일',
+    category: '개발',
+    tags: [],
+    preview: { html: '', text: '' },
+    readingTime: 2,
+    isIndexFile: false,
+    headings: [],
+    previous: { slug: 'older-post', title: '이전 글' },
+    next: { slug: 'newer-post', title: '다음 글' }
+  },
+  component: SocialLinks,
+  dynamicDescription: '현재 글 설명',
+  jsonLd: '{}',
+  breadcrumbLd: '{}',
+  socialMediaImage: 'https://blog.nanggo.net/og.png',
+  isPostImage: false,
+  publishedDate: '2026-07-10T00:00:00.000Z',
+  modifiedDate: '2026-07-10T00:00:00.000Z',
+  layout: { fullWidth: true }
+}
+
+describe('포스트 상세 페이지', () => {
+  it('홈부터 현재 글까지 breadcrumb을 노출한다', () => {
+    render(Page, { data: data as never })
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' })
+    const links = within(breadcrumb).getAllByRole('link')
+
+    expect(links.map((link) => link.textContent)).toEqual(['홈', '포스트', '개발'])
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/',
+      '/posts',
+      '/posts/category/%EA%B0%9C%EB%B0%9C'
+    ])
+    expect(within(breadcrumb).getByText('현재 글')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('접근 가능한 이전·다음 글 링크를 노출하고 canonical을 유지한다', () => {
+    render(Page, { data: data as never })
+
+    const navigation = screen.getByRole('navigation', { name: '포스트 탐색' })
+    const previousLink = within(navigation).getByRole('link', { name: '이전 글: 이전 글' })
+    const nextLink = within(navigation).getByRole('link', { name: '다음 글: 다음 글' })
+
+    expect(previousLink).toHaveAttribute('href', '/post/older-post')
+    expect(previousLink).toHaveClass('focus-visible:ring-2')
+    expect(nextLink).toHaveAttribute('href', '/post/newer-post')
+    expect(nextLink).toHaveClass('focus-visible:ring-2')
+    expect(document.head.querySelector('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      'https://blog.nanggo.net/post/current-post'
+    )
+  })
+})

--- a/src/routes/post/[slug]/PageServer.test.ts
+++ b/src/routes/post/[slug]/PageServer.test.ts
@@ -1,0 +1,80 @@
+// Route-level contract tests for server-generated post metadata.
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockPost } = vi.hoisted(() => ({
+  mockPost: {
+    slug: 'current-post',
+    title: '현재 글',
+    description: '현재 글 설명',
+    date: '2026-07-10',
+    displayDate: '2026년 7월 10일',
+    category: '개발',
+    tags: ['svelte'],
+    preview: { html: '<p>현재 글 설명</p>', text: '현재 글 설명' },
+    readingTime: 2,
+    isIndexFile: false,
+    headings: [],
+    previous: { slug: 'older-post', title: '이전 글' },
+    next: { slug: 'newer-post', title: '다음 글' }
+  }
+}))
+
+vi.mock('$lib/data/posts', () => ({ posts: [mockPost] }))
+vi.mock('$lib/info', () => ({
+  website: 'https://example.com',
+  author: '낭고',
+  defaultOgImage: 'https://example.com/og.png',
+  name: '낭고넷'
+}))
+
+import { load } from './+page.server'
+
+describe('포스트 상세 서버 로드', () => {
+  it('화면과 동일한 4단계 breadcrumb JSON-LD를 제공한다', async () => {
+    const result = await load({ params: { slug: mockPost.slug } } as never)
+
+    expect(result).toBeTruthy()
+    if (!result) throw new Error('포스트 데이터가 없습니다.')
+
+    const breadcrumb = JSON.parse(result.breadcrumbLd as string)
+
+    expect(breadcrumb.itemListElement).toEqual([
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: '홈',
+        item: 'https://example.com/'
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: '포스트',
+        item: 'https://example.com/posts'
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: '개발',
+        item: 'https://example.com/posts/category/%EA%B0%9C%EB%B0%9C'
+      },
+      {
+        '@type': 'ListItem',
+        position: 4,
+        name: '현재 글',
+        item: 'https://example.com/post/current-post'
+      }
+    ])
+  })
+
+  it('이전·다음 글 메타데이터를 상세 페이지에 전달한다', async () => {
+    const result = await load({ params: { slug: mockPost.slug } } as never)
+
+    expect(result).toBeTruthy()
+    if (!result) throw new Error('포스트 데이터가 없습니다.')
+
+    expect(result.post).toMatchObject({
+      previous: mockPost.previous,
+      next: mockPost.next
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add accessible previous/next post links to article pages
- expand visible and JSON-LD breadcrumbs to Home → Posts → Category → Current post
- make long breadcrumb labels wrap safely on narrow screens
- add route-level tests for navigation links, canonical URLs, and breadcrumb data

## Validation

- `pnpm test:run -- 'src/routes/post/[slug]/Page.test.ts' 'src/routes/post/[slug]/PageServer.test.ts'` (18 files, 223 tests passed)
- `pnpm check` (0 errors, 0 warnings)
- `pnpm seo:validate` (41/41 pages valid, 0 errors; existing 2 warnings)
- adversarial accessibility/navigation review: no findings
- `git diff --check`