### PR TITLE
chore(deps): bump js-yaml to 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 		"github-slugger": "^2.0.0",
 		"gray-matter": "^4.0.3",
 		"heroicons-svelte": "^2.0.2",
-		"js-yaml": "^4.3.0",
+		"js-yaml": "^5.2.1",
 		"node-html-parser": "^5.4.1",
 		"reading-time": "^1.5.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.55.7(@typescript-eslint/types@8.38.0))
       js-yaml:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^5.2.1
+        version: 5.2.1
       node-html-parser:
         specifier: ^5.4.1
         version: 5.4.2
@@ -2307,6 +2307,10 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -5806,6 +5810,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

- replace the unsafe js-yaml 5.0.0 proposal with js-yaml 5.2.1
- update the direct dependency specifier and lockfile without unrelated churn
- include the upstream 5.2.1 fix for the v5 !!omap quadratic-complexity regression

This supersedes #133. Upstream notes: https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#521---2026-07-02

## Compatibility

- the application and repository scripts do not import js-yaml directly
- the existing Vite manual chunk and optimizeDeps entries resolve and prebundle 5.2.1 successfully
- gray-matter and ESLint keep their independent transitive js-yaml versions

## Validation

- pnpm install --frozen-lockfile
- pnpm check (0 errors, 0 warnings)
- pnpm lint (0 errors; existing 44 warnings)
- pnpm test:coverage (21 files, 234 tests passed; all thresholds passed)
- pnpm build
- git diff --check
