### PR TITLE
chore(deps): remove unused js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
 		"github-slugger": "^2.0.0",
 		"gray-matter": "^4.0.3",
 		"heroicons-svelte": "^2.0.2",
-		"js-yaml": "^5.2.1",
 		"node-html-parser": "^5.4.1",
 		"reading-time": "^1.5.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       heroicons-svelte:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.55.7(@typescript-eslint/types@8.38.0))
-      js-yaml:
-        specifier: ^5.2.1
-        version: 5.2.1
       node-html-parser:
         specifier: ^5.4.1
         version: 5.4.2
@@ -2307,10 +2304,6 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -5810,10 +5803,6 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,7 +77,7 @@ export default defineConfig(({ mode }) => ({
               'github-slugger',
               'node-html-parser'
             ],
-            'utils-vendor': ['date-fns', 'clsx', 'js-yaml', 'heroicons-svelte']
+            'utils-vendor': ['date-fns', 'clsx', 'heroicons-svelte']
           }
 
           // 스코프 패키지를 포함한 정확한 패키지 매칭
@@ -119,7 +119,7 @@ export default defineConfig(({ mode }) => ({
   },
   optimizeDeps: {
     // Tree shaking 최적화를 위한 pre-bundling
-    include: ['date-fns', 'clsx', 'js-yaml', 'github-slugger', 'node-html-parser', 'reading-time'],
+    include: ['date-fns', 'clsx', 'github-slugger', 'node-html-parser', 'reading-time'],
     // 개발 시 빠른 빌드를 위한 exclude
     exclude: ['@sveltejs/kit', 'svelte']
   }


### PR DESCRIPTION
## Summary

- remove the orphan direct js-yaml dependency and its direct lockfile entries
- remove stale js-yaml entries from Vite manualChunks and optimizeDeps
- preserve the js-yaml <3.14.2 security override and the gray-matter/ESLint transitive versions

## Why

js-yaml was originally added for scripts/convert-tags.js, which was later deleted. No current application, script, test, static import, dynamic import, or re-export consumes the direct package. Keeping it forced an unnecessary dev prebundle and created avoidable dependency maintenance.

## Impact

- one fewer direct production dependency
- no forced js-yaml dev prebundle
- no application or production behavior change

## Validation

- pnpm install --frozen-lockfile
- vite optimizeDeps forced re-optimization without js-yaml
- pnpm check (0 errors, 0 warnings)
- pnpm lint (0 errors; existing 44 warnings)
- pnpm test:coverage (21 files, 234 tests passed; all thresholds passed)
- pnpm build
- pnpm why js-yaml (only gray-matter 3.14.2 and ESLint 4.3.0 remain)
- repository-wide js-yaml reference audit
- git diff --check
