### PR TITLE
perf: preload visible post data

### DIFF
--- a/src/lib/actions/preload-data-on-viewport.test.ts
+++ b/src/lib/actions/preload-data-on-viewport.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { preloadDataOnViewport } from './preload-data-on-viewport'
+
+const { preloadDataMock } = vi.hoisted(() => ({
+  preloadDataMock: vi.fn()
+}))
+
+vi.mock('$app/navigation', () => ({
+  preloadData: preloadDataMock
+}))
+
+interface TestObserver {
+  callback: ObserverCallback
+  disconnect: ReturnType<typeof vi.fn>
+  observe: ReturnType<typeof vi.fn>
+  options?: ObserverOptions
+  unobserve: ReturnType<typeof vi.fn>
+}
+
+type ObserverCallback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver
+) => void
+type ObserverOptions = {
+  root?: Element | null
+  rootMargin?: string
+  threshold?: number | number[]
+}
+type TestAction = ReturnType<typeof preloadDataOnViewport>
+
+const actions: TestAction[] = []
+const observers: TestObserver[] = []
+const originalConnection = Object.getOwnPropertyDescriptor(navigator, 'connection')
+
+class MockIntersectionObserver {
+  callback: ObserverCallback
+  disconnect = vi.fn()
+  observe = vi.fn()
+  options?: ObserverOptions
+  unobserve = vi.fn()
+
+  constructor(callback: ObserverCallback, options?: ObserverOptions) {
+    this.callback = callback
+    this.options = options
+    observers.push(this)
+  }
+
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds = []
+}
+
+const createAction = (
+  node: HTMLAnchorElement,
+  options: Parameters<typeof preloadDataOnViewport>[1] = {}
+): TestAction => {
+  const action = preloadDataOnViewport(node, options)
+  actions.push(action)
+  return action
+}
+
+const setSaveData = (saveData: boolean): void => {
+  Object.defineProperty(navigator, 'connection', {
+    configurable: true,
+    value: { saveData }
+  })
+}
+
+const entry = (
+  node: Element,
+  {
+    intersectionRatio = 1,
+    isIntersecting = true
+  }: { intersectionRatio?: number; isIntersecting?: boolean } = {}
+): IntersectionObserverEntry =>
+  ({
+    intersectionRatio,
+    isIntersecting,
+    target: node
+  }) as IntersectionObserverEntry
+
+const intersect = (observer: TestObserver, entries: IntersectionObserverEntry[]): void => {
+  observer.callback(entries, observer as unknown as IntersectionObserver)
+}
+
+const rectAt = (top: number, height = 100): DOMRect =>
+  ({
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 100,
+    top,
+    width: 100,
+    x: 0,
+    y: top,
+    toJSON: () => ({})
+  }) as DOMRect
+
+describe('preloadDataOnViewport', () => {
+  beforeEach(() => {
+    actions.length = 0
+    observers.length = 0
+    preloadDataMock.mockReset()
+    preloadDataMock.mockResolvedValue({ type: 'loaded', status: 200, data: {} })
+    setSaveData(false)
+    vi.stubGlobal(
+      'IntersectionObserver',
+      MockIntersectionObserver as unknown as typeof IntersectionObserver
+    )
+  })
+
+  afterEach(() => {
+    for (const action of actions) {
+      action.destroy()
+    }
+
+    vi.unstubAllGlobals()
+
+    if (originalConnection) {
+      Object.defineProperty(navigator, 'connection', originalConnection)
+    } else {
+      Reflect.deleteProperty(navigator, 'connection')
+    }
+  })
+
+  it('viewport 중앙의 링크 데이터를 선로딩하고 같은 후보를 중복 요청하지 않는다', async () => {
+    const node = document.createElement('a')
+    const action = createAction(node, { href: '/post/test-post' })
+    const observer = observers[0]
+
+    expect(observer.observe).toHaveBeenCalledWith(node)
+    expect(observer.options).toEqual({
+      rootMargin: '0px',
+      threshold: 0.5
+    })
+
+    intersect(observer, [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/post/test-post')
+    expect(observer.disconnect).not.toHaveBeenCalled()
+
+    intersect(observer, [entry(node)])
+    await Promise.resolve()
+    action.update({ href: '/post/test-post' })
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(observers).toHaveLength(1)
+
+    action.destroy()
+    expect(observer.unobserve).toHaveBeenCalledWith(node)
+    expect(observer.disconnect).toHaveBeenCalledOnce()
+  })
+
+  it('여러 링크 중 화면 중앙에 가장 가까운 후보 하나만 유지한다', async () => {
+    const upperNode = document.createElement('a')
+    const centerNode = document.createElement('a')
+    vi.spyOn(upperNode, 'getBoundingClientRect').mockReturnValue(rectAt(0))
+    vi.spyOn(centerNode, 'getBoundingClientRect').mockReturnValue(
+      rectAt(window.innerHeight / 2 - 50)
+    )
+
+    createAction(upperNode, { href: '/post/upper' })
+    createAction(centerNode, { href: '/post/center' })
+
+    expect(observers).toHaveLength(1)
+    const observer = observers[0]
+    intersect(observer, [entry(upperNode), entry(centerNode)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledTimes(1)
+    expect(preloadDataMock).toHaveBeenLastCalledWith('/post/center')
+
+    intersect(observer, [entry(centerNode, { intersectionRatio: 0, isIntersecting: false })])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledTimes(2)
+    expect(preloadDataMock).toHaveBeenLastCalledWith('/post/upper')
+  })
+
+  it('priority가 높은 페이지네이션 후보를 글 카드보다 우선한다', async () => {
+    const postNode = document.createElement('a')
+    const nextNode = document.createElement('a')
+    vi.spyOn(postNode, 'getBoundingClientRect').mockReturnValue(rectAt(window.innerHeight / 2 - 50))
+    vi.spyOn(nextNode, 'getBoundingClientRect').mockReturnValue(rectAt(window.innerHeight - 100))
+
+    createAction(postNode, { href: '/post/test-post' })
+    createAction(nextNode, { href: '/posts/2', priority: 1 })
+
+    const observer = observers[0]
+    intersect(observer, [entry(postNode), entry(nextNode)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/posts/2')
+  })
+
+  it('href 갱신 전 observer의 지연된 콜백을 무시한다', async () => {
+    const node = document.createElement('a')
+    const action = createAction(node, { href: '/posts/2' })
+    const staleObserver = observers[0]
+
+    action.update({ href: '/posts/3' })
+
+    expect(observers).toHaveLength(2)
+    expect(staleObserver.unobserve).toHaveBeenCalledWith(node)
+    expect(staleObserver.disconnect).toHaveBeenCalledOnce()
+
+    intersect(staleObserver, [entry(node)])
+    await Promise.resolve()
+    expect(preloadDataMock).not.toHaveBeenCalled()
+
+    const currentObserver = observers[1]
+    intersect(currentObserver, [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/posts/3')
+  })
+
+  it('데이터 절약 모드에서는 선로딩하지 않는다', () => {
+    setSaveData(true)
+
+    createAction(document.createElement('a'), { href: '/post/test-post' })
+
+    expect(observers).toHaveLength(0)
+    expect(preloadDataMock).not.toHaveBeenCalled()
+  })
+
+  it('데스크탑에서는 viewport 데이터 선로딩을 추가하지 않는다', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true } as MediaQueryList))
+
+    createAction(document.createElement('a'), { href: '/post/test-post' })
+
+    expect(observers).toHaveLength(0)
+    expect(preloadDataMock).not.toHaveBeenCalled()
+  })
+
+  it('비활성화되거나 목적지가 없으면 관찰하지 않는다', () => {
+    createAction(document.createElement('a'), {
+      enabled: false,
+      href: '/post/test-post'
+    })
+    createAction(document.createElement('a'))
+
+    expect(observers).toHaveLength(0)
+  })
+})

--- a/src/lib/actions/preload-data-on-viewport.ts
+++ b/src/lib/actions/preload-data-on-viewport.ts
@@ -1,0 +1,173 @@
+import { preloadData } from '$app/navigation'
+import { createOptimizedIntersectionObserver } from '$lib/utils/performance'
+
+interface NetworkInformation {
+  saveData?: boolean
+}
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: NetworkInformation
+}
+
+export interface PreloadDataOnViewportOptions {
+  enabled?: boolean
+  href?: string
+  priority?: number
+}
+
+interface PreloadCandidate {
+  href: string
+  intersectionRatio: number
+  node: HTMLAnchorElement
+  priority: number
+  visible: boolean
+}
+
+const candidates = new Map<HTMLAnchorElement, PreloadCandidate>()
+
+let activePreloadHref: string | null = null
+let observer: IntersectionObserver | null = null
+let observerGeneration = 0
+let selectionScheduled = false
+
+const shouldSkipPreload = (): boolean => {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return true
+  if (window.matchMedia('(min-width: 768px)').matches) return true
+
+  return (navigator as NavigatorWithConnection).connection?.saveData === true
+}
+
+const selectDominantCandidate = (): void => {
+  selectionScheduled = false
+
+  const visibleCandidates = Array.from(candidates.values()).filter((candidate) => candidate.visible)
+  if (visibleCandidates.length === 0) {
+    activePreloadHref = null
+    return
+  }
+
+  const viewportCenter = window.innerHeight / 2
+  visibleCandidates.sort((left, right) => {
+    const priorityDifference = right.priority - left.priority
+    if (priorityDifference !== 0) return priorityDifference
+
+    const ratioDifference = right.intersectionRatio - left.intersectionRatio
+    if (ratioDifference !== 0) return ratioDifference
+
+    const leftRect = left.node.getBoundingClientRect()
+    const rightRect = right.node.getBoundingClientRect()
+    const leftDistance = Math.abs(leftRect.top + leftRect.height / 2 - viewportCenter)
+    const rightDistance = Math.abs(rightRect.top + rightRect.height / 2 - viewportCenter)
+    return leftDistance - rightDistance
+  })
+
+  const nextCandidate = visibleCandidates[0]
+  if (nextCandidate.href === activePreloadHref) return
+
+  activePreloadHref = nextCandidate.href
+  void preloadData(nextCandidate.href).catch(() => {
+    if (activePreloadHref === nextCandidate.href) {
+      activePreloadHref = null
+    }
+  })
+}
+
+const scheduleCandidateSelection = (): void => {
+  if (selectionScheduled) return
+
+  selectionScheduled = true
+  queueMicrotask(selectDominantCandidate)
+}
+
+const ensureObserver = (): IntersectionObserver | null => {
+  if (observer) return observer
+
+  const generation = ++observerGeneration
+  observer = createOptimizedIntersectionObserver(
+    (entries) => {
+      if (generation !== observerGeneration) return
+
+      for (const entry of entries) {
+        const candidate = candidates.get(entry.target as HTMLAnchorElement)
+        if (!candidate) continue
+
+        candidate.intersectionRatio = entry.intersectionRatio
+        candidate.visible = entry.isIntersecting && entry.intersectionRatio >= 0.5
+      }
+      scheduleCandidateSelection()
+    },
+    {
+      rootMargin: '0px',
+      threshold: 0.5
+    }
+  )
+
+  return observer
+}
+
+const unregisterCandidate = (node: HTMLAnchorElement): void => {
+  observer?.unobserve(node)
+  candidates.delete(node)
+
+  if (candidates.size === 0) {
+    observer?.disconnect()
+    observer = null
+    observerGeneration += 1
+    activePreloadHref = null
+    return
+  }
+
+  scheduleCandidateSelection()
+}
+
+const registerCandidate = (
+  node: HTMLAnchorElement,
+  options: PreloadDataOnViewportOptions
+): boolean => {
+  const href = options.href?.trim()
+  if (options.enabled === false || !href || shouldSkipPreload()) return false
+
+  const sharedObserver = ensureObserver()
+  if (!sharedObserver) return false
+
+  candidates.set(node, {
+    href,
+    intersectionRatio: 0,
+    node,
+    priority: options.priority ?? 0,
+    visible: false
+  })
+  sharedObserver.observe(node)
+  return true
+}
+
+export const preloadDataOnViewport = (
+  node: HTMLAnchorElement,
+  initialOptions: PreloadDataOnViewportOptions = {}
+) => {
+  let options = initialOptions
+  let registered = registerCandidate(node, options)
+
+  return {
+    update(nextOptions: PreloadDataOnViewportOptions = {}): void {
+      const unchanged =
+        nextOptions.enabled === options.enabled &&
+        nextOptions.href?.trim() === options.href?.trim() &&
+        nextOptions.priority === options.priority
+      if (unchanged) return
+
+      if (registered) {
+        unregisterCandidate(node)
+      }
+
+      options = nextOptions
+      registered = registerCandidate(node, options)
+    },
+    destroy(): void {
+      if (registered) {
+        unregisterCandidate(node)
+        registered = false
+      }
+    }
+  }
+}

--- a/src/lib/components/layout/Pagination.svelte
+++ b/src/lib/components/layout/Pagination.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { ArrowLeftIcon, ArrowRightIcon } from '../ui/Icon'
 
+  import { preloadDataOnViewport } from '$lib/actions/preload-data-on-viewport'
+
   export let currentPage: number
   export let totalPages: number
   export let getPageUrl: (_page: number) => string
@@ -11,6 +13,10 @@
     <a
       href={getPageUrl(currentPage - 1)}
       class="flex items-center gap-1 text-sm font-medium text-teal-500 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
+      use:preloadDataOnViewport={{
+        href: getPageUrl(currentPage - 1),
+        enabled: currentPage >= totalPages
+      }}
     >
       <ArrowLeftIcon class="w-4 h-4" />
       Previous
@@ -28,6 +34,10 @@
     <a
       href={getPageUrl(currentPage + 1)}
       class="flex items-center gap-1 text-sm font-medium text-teal-500 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
+      use:preloadDataOnViewport={{
+        href: getPageUrl(currentPage + 1),
+        priority: 1
+      }}
     >
       Next
       <ArrowRightIcon class="w-4 h-4" />

--- a/src/lib/components/layout/Pagination.test.ts
+++ b/src/lib/components/layout/Pagination.test.ts
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import Pagination from './Pagination.svelte'
+
+const observedLinks: Element[] = []
+
+class TrackingIntersectionObserver {
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds = []
+
+  observe(node: Element): void {
+    observedLinks.push(node)
+  }
+}
+
+describe('Pagination', () => {
+  afterEach(() => {
+    observedLinks.length = 0
+    vi.unstubAllGlobals()
+  })
+
+  it('다음 목록 페이지 링크를 viewport 선로딩 대상으로 등록한다', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      TrackingIntersectionObserver as unknown as typeof IntersectionObserver
+    )
+
+    render(Pagination, {
+      currentPage: 1,
+      totalPages: 3,
+      getPageUrl: (page: number) => (page === 1 ? '/posts' : `/posts/${page}`)
+    })
+
+    const nextLink = screen.getByRole('link', { name: 'Next' })
+    expect(nextLink).toHaveAttribute('href', '/posts/2')
+    expect(observedLinks).toEqual([nextLink])
+  })
+
+  it('중간 페이지에서는 다음 페이지만 viewport 선로딩 대상으로 등록한다', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      TrackingIntersectionObserver as unknown as typeof IntersectionObserver
+    )
+
+    render(Pagination, {
+      currentPage: 2,
+      totalPages: 3,
+      getPageUrl: (page: number) => (page === 1 ? '/posts' : `/posts/${page}`)
+    })
+
+    const previousLink = screen.getByRole('link', { name: 'Previous' })
+    const nextLink = screen.getByRole('link', { name: 'Next' })
+
+    expect(previousLink).toHaveAttribute('href', '/posts')
+    expect(nextLink).toHaveAttribute('href', '/posts/3')
+    expect(observedLinks).toEqual([nextLink])
+  })
+
+  it('마지막 페이지에서는 이전 페이지만 viewport 선로딩 대상으로 등록한다', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      TrackingIntersectionObserver as unknown as typeof IntersectionObserver
+    )
+
+    render(Pagination, {
+      currentPage: 3,
+      totalPages: 3,
+      getPageUrl: (page: number) => (page === 1 ? '/posts' : `/posts/${page}`)
+    })
+
+    const previousLink = screen.getByRole('link', { name: 'Previous' })
+    expect(previousLink).toHaveAttribute('href', '/posts/2')
+    expect(screen.queryByRole('link', { name: 'Next' })).not.toBeInTheDocument()
+    expect(observedLinks).toEqual([previousLink])
+  })
+})

--- a/src/lib/components/post/PostPreview.svelte
+++ b/src/lib/components/post/PostPreview.svelte
@@ -35,7 +35,7 @@
   }
 </script>
 
-<Card href={getSafeUrl(post.slug)}>
+<Card href={getSafeUrl(post.slug)} preloadDataOnViewport>
   <slot slot="eyebrow" name="eyebrow" />
   <slot slot="title">{post.title}</slot>
   <div slot="description" class="prose dark:prose-invert">

--- a/src/lib/components/post/PostPreview.test.ts
+++ b/src/lib/components/post/PostPreview.test.ts
@@ -49,6 +49,35 @@ describe('PostPreview 컴포넌트', () => {
     expect(cardLink).toHaveAttribute('data-sveltekit-preload-code', 'viewport')
   })
 
+  it('카드 상세 링크를 viewport 선로딩 대상으로 등록한다', () => {
+    const observedLinks: Element[] = []
+
+    class TrackingIntersectionObserver {
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+      takeRecords = vi.fn(() => [])
+      root = null
+      rootMargin = ''
+      thresholds = []
+
+      observe(node: Element): void {
+        observedLinks.push(node)
+      }
+    }
+
+    vi.stubGlobal(
+      'IntersectionObserver',
+      TrackingIntersectionObserver as unknown as typeof IntersectionObserver
+    )
+
+    render(PostPreview, { post: mockPost })
+
+    const cardLink = document.querySelector('a[href="/post/test-post-slug"]')
+    expect(observedLinks).toContain(cardLink)
+
+    vi.unstubAllGlobals()
+  })
+
   it('최대 태그 개수만큼 태그가 표시된다', () => {
     render(PostPreview, { post: mockPost, maxTagsToShow: 2 })
 

--- a/src/lib/components/ui/Card/Card.svelte
+++ b/src/lib/components/ui/Card/Card.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { preloadDataOnViewport as preloadDataOnViewportAction } from '$lib/actions/preload-data-on-viewport'
+
   export let as: string = 'div'
   export let href: string | undefined = undefined
+  export let preloadDataOnViewport: boolean = false
 
   let _class: string | undefined = undefined
   export { _class as class }
@@ -20,7 +23,12 @@
           class="absolute z-0 transition scale-95 opacity-0 -inset-y-6 -inset-x-4 bg-zinc-50 group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl"
         ></div>
 
-        <a {href} data-sveltekit-preload-data="hover" data-sveltekit-preload-code="viewport">
+        <a
+          {href}
+          data-sveltekit-preload-data="hover"
+          data-sveltekit-preload-code="viewport"
+          use:preloadDataOnViewportAction={{ href, enabled: preloadDataOnViewport }}
+        >
           <span class="absolute z-20 -inset-y-6 -inset-x-4 sm:-inset-x-6 sm:rounded-2xl"></span>
           <span class="relative z-10">
             <slot name="title" />


### PR DESCRIPTION
## What

- Mobile viewport에서 가장 유력한 글 링크 하나의 route data와 Markdown chunk를 미리 받습니다.
- SvelteKit 단일 preload cache를 지키도록 공용 coordinator를 사용하고, stale observer callback을 차단합니다.
- 목록 하단에서는 Next를 우선하고 마지막 페이지에서만 Previous를 대상으로 삼습니다.
- Save-Data와 데스크탑은 추가 data preload를 건너뛰며 일반 href와 prerender HTML을 유지합니다.

## Why

모바일 탭 시 상세 route data와 컴파일된 Markdown chunk를 받은 뒤 페이지가 바뀌어 이미지 요청 전에 체감 지연이 있었습니다. 터치 전에 유력한 대상 하나만 준비해 페이지와 제목을 먼저 전환하고 히어로 이미지는 이후 렌더링되게 합니다.

## Verification

- 최종 적대적 리뷰: Blocker 0, Recommendation 0
- pnpm test:run: 27 files, 265 tests passed
- pnpm check: 0 errors, 0 warnings
- pnpm lint: 0 errors, 기존 44 warnings
- pnpm seo:validate: 73/73 pages, 0 errors, 0 warnings
- Chrome 390x844 Slow 3G: 글 URL 70ms, heading 99ms; 그 시점 hero 미완료, 클릭 후 관련 요청은 672w image only
- 목록 1→2: URL 77ms, content 103ms; /posts/2 data 재요청 없음