### PR TITLE
perf: preload profile data on viewport

### DIFF
--- a/src/lib/actions/preload-data-on-viewport.test.ts
+++ b/src/lib/actions/preload-data-on-viewport.test.ts
@@ -224,7 +224,10 @@ describe('preloadDataOnViewport', () => {
   it('데이터 절약 모드에서는 선로딩하지 않는다', () => {
     setSaveData(true)
 
-    createAction(document.createElement('a'), { href: '/post/test-post' })
+    createAction(document.createElement('a'), {
+      deviceScope: 'all',
+      href: '/about'
+    })
 
     expect(observers).toHaveLength(0)
     expect(preloadDataMock).not.toHaveBeenCalled()
@@ -237,6 +240,46 @@ describe('preloadDataOnViewport', () => {
 
     expect(observers).toHaveLength(0)
     expect(preloadDataMock).not.toHaveBeenCalled()
+  })
+
+  it('모든 기기 대상 링크는 데스크탑에서도 viewport 데이터를 선로딩한다', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true } as MediaQueryList))
+    const node = document.createElement('a')
+
+    createAction(node, {
+      deviceScope: 'all',
+      href: '/about'
+    })
+
+    expect(observers).toHaveLength(1)
+    intersect(observers[0], [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/about')
+  })
+
+  it('기기 범위가 all로 갱신되면 데스크탑에서도 관찰을 시작한다', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true } as MediaQueryList))
+    const node = document.createElement('a')
+    const action = createAction(node, {
+      deviceScope: 'mobile',
+      href: '/about'
+    })
+
+    expect(observers).toHaveLength(0)
+
+    action.update({
+      deviceScope: 'all',
+      href: '/about'
+    })
+
+    expect(observers).toHaveLength(1)
+    intersect(observers[0], [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/about')
   })
 
   it('비활성화되거나 목적지가 없으면 관찰하지 않는다', () => {

--- a/src/lib/actions/preload-data-on-viewport.ts
+++ b/src/lib/actions/preload-data-on-viewport.ts
@@ -10,6 +10,7 @@ interface NavigatorWithConnection extends Navigator {
 }
 
 export interface PreloadDataOnViewportOptions {
+  deviceScope?: 'all' | 'mobile'
   enabled?: boolean
   href?: string
   priority?: number
@@ -30,9 +31,11 @@ let observer: IntersectionObserver | null = null
 let observerGeneration = 0
 let selectionScheduled = false
 
-const shouldSkipPreload = (): boolean => {
+const shouldSkipPreload = (options: PreloadDataOnViewportOptions): boolean => {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return true
-  if (window.matchMedia('(min-width: 768px)').matches) return true
+  if (options.deviceScope !== 'all' && window.matchMedia('(min-width: 768px)').matches) {
+    return true
+  }
 
   return (navigator as NavigatorWithConnection).connection?.saveData === true
 }
@@ -125,7 +128,7 @@ const registerCandidate = (
   options: PreloadDataOnViewportOptions
 ): boolean => {
   const href = options.href?.trim()
-  if (options.enabled === false || !href || shouldSkipPreload()) return false
+  if (options.enabled === false || !href || shouldSkipPreload(options)) return false
 
   const sharedObserver = ensureObserver()
   if (!sharedObserver) return false
@@ -151,6 +154,7 @@ export const preloadDataOnViewport = (
   return {
     update(nextOptions: PreloadDataOnViewportOptions = {}): void {
       const unchanged =
+        nextOptions.deviceScope === options.deviceScope &&
         nextOptions.enabled === options.enabled &&
         nextOptions.href?.trim() === options.href?.trim() &&
         nextOptions.priority === options.priority

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { PageData } from './$types'
 
+  import { preloadDataOnViewport } from '$lib/actions/preload-data-on-viewport'
   import { CategoryFilter } from '$lib/components'
   import { SocialLinks } from '$lib/components/layout'
   import { PostsList } from '$lib/components/post'
@@ -35,6 +36,7 @@
         class="inline-block rounded-full"
         data-sveltekit-preload-data="hover"
         data-sveltekit-preload-code="viewport"
+        use:preloadDataOnViewport={{ deviceScope: 'all', href: '/about', priority: 1 }}
       >
         <img
           src="{avatarBase}?s=288"


### PR DESCRIPTION
## What changed

- add an explicit `deviceScope` option to the shared viewport data preload action
- preload the homepage profile link on both desktop and mobile
- keep post cards and pagination on their existing mobile-only viewport policy
- preserve hover/touch fallback and data-saver behavior
- cover desktop opt-in, option updates, and data-saver behavior with tests

## Why

The profile route code was preloaded, but `/about/__data.json` and the Markdown component were still requested after a quick click. That produced about 360 ms of delay on a normal connection and about 949 ms under Slow 3G. The profile payload is small enough to preload while the always-visible profile link is in the viewport.

## Impact

The profile page is ready before interaction without causing visible post data to preload on desktop. In the production preview, the About data and Markdown chunk loaded before the click and the preloaded transition rendered in about 22 ms.

## Validation

- `pnpm test:run -- src/lib/actions/preload-data-on-viewport.test.ts` (27 files, 267 tests passed)
- `pnpm check`
- targeted Prettier and ESLint checks
- `pnpm build`
- production-preview browser verification
- read-only adversarial review: no actionable findings