### PR TITLE
perf: preload tag result navigation

### DIFF
--- a/src/lib/actions/preload-data-on-viewport.test.ts
+++ b/src/lib/actions/preload-data-on-viewport.test.ts
@@ -2,12 +2,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { preloadDataOnViewport } from './preload-data-on-viewport'
 
-const { preloadDataMock } = vi.hoisted(() => ({
-  preloadDataMock: vi.fn()
-}))
+const { pageSubscribeMock, pageSubscribers, preloadDataMock } = vi.hoisted(() => {
+  const pageSubscribers = new Set<(value: { url: URL }) => void>()
+
+  return {
+    pageSubscribers,
+    pageSubscribeMock: vi.fn((subscriber: (value: { url: URL }) => void) => {
+      pageSubscribers.add(subscriber)
+      subscriber({ url: new URL(window.location.href) })
+      return () => pageSubscribers.delete(subscriber)
+    }),
+    preloadDataMock: vi.fn()
+  }
+})
 
 vi.mock('$app/navigation', () => ({
   preloadData: preloadDataMock
+}))
+
+vi.mock('$app/stores', () => ({
+  page: { subscribe: pageSubscribeMock }
 }))
 
 interface TestObserver {
@@ -32,6 +46,7 @@ type TestAction = ReturnType<typeof preloadDataOnViewport>
 const actions: TestAction[] = []
 const observers: TestObserver[] = []
 const originalConnection = Object.getOwnPropertyDescriptor(navigator, 'connection')
+const originalUrl = window.location.href
 
 class MockIntersectionObserver {
   callback: ObserverCallback
@@ -102,6 +117,8 @@ describe('preloadDataOnViewport', () => {
   beforeEach(() => {
     actions.length = 0
     observers.length = 0
+    pageSubscribers.clear()
+    pageSubscribeMock.mockClear()
     preloadDataMock.mockReset()
     preloadDataMock.mockResolvedValue({ type: 'loaded', status: 200, data: {} })
     setSaveData(false)
@@ -117,6 +134,7 @@ describe('preloadDataOnViewport', () => {
     }
 
     vi.unstubAllGlobals()
+    window.history.replaceState({}, '', originalUrl)
 
     if (originalConnection) {
       Object.defineProperty(navigator, 'connection', originalConnection)
@@ -181,6 +199,73 @@ describe('preloadDataOnViewport', () => {
     expect(preloadDataMock).toHaveBeenLastCalledWith('/post/upper')
   })
 
+  it('현재 URL은 후보에서 제외하고 다른 가시 링크를 선로딩한다', async () => {
+    window.history.replaceState({}, '', '/tags/svelte?sort=recent')
+    const currentNode = document.createElement('a')
+    const otherNode = document.createElement('a')
+    vi.spyOn(currentNode, 'getBoundingClientRect').mockReturnValue(
+      rectAt(window.innerHeight / 2 - 50)
+    )
+    vi.spyOn(otherNode, 'getBoundingClientRect').mockReturnValue(rectAt(0))
+
+    createAction(currentNode, { href: '/tags/svelte?sort=recent#posts' })
+    createAction(otherNode, { href: '/post/other' })
+
+    expect(observers).toHaveLength(1)
+    intersect(observers[0], [entry(currentNode), entry(otherNode)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/post/other')
+  })
+
+  it('같은 route 안에서 이동하면 현재 URL 후보를 다시 판정한다', async () => {
+    window.history.replaceState({}, '', '/tags/frontend')
+    const frontendNode = document.createElement('a')
+    const testingNode = document.createElement('a')
+
+    createAction(frontendNode, { href: '/tags/frontend' })
+    createAction(testingNode, { href: '/tags/testing' })
+
+    intersect(observers[0], [entry(frontendNode), entry(testingNode)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/testing')
+
+    preloadDataMock.mockClear()
+    window.history.replaceState({}, '', '/tags/testing')
+    for (const subscriber of pageSubscribers) {
+      subscriber({ url: new URL(window.location.href) })
+    }
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/frontend')
+  })
+
+  it('페이지 이동으로 SvelteKit 캐시가 바뀌면 같은 dominant 후보를 다시 선로딩한다', async () => {
+    window.history.replaceState({}, '', '/tags/frontend')
+    const node = document.createElement('a')
+
+    createAction(node, { href: '/tags/testing' })
+    intersect(observers[0], [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/testing')
+
+    preloadDataMock.mockClear()
+    window.history.replaceState({}, '', '/tags/design')
+    for (const subscriber of pageSubscribers) {
+      subscriber({ url: new URL(window.location.href) })
+    }
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/testing')
+  })
+
   it('priority가 높은 페이지네이션 후보를 글 카드보다 우선한다', async () => {
     const postNode = document.createElement('a')
     const nextNode = document.createElement('a')
@@ -233,6 +318,20 @@ describe('preloadDataOnViewport', () => {
     expect(preloadDataMock).not.toHaveBeenCalled()
   })
 
+  it('matchMedia 결과가 없는 환경에서도 모바일 후보를 선로딩한다', async () => {
+    vi.stubGlobal('matchMedia', vi.fn())
+    const node = document.createElement('a')
+
+    createAction(node, { href: '/tags/svelte' })
+
+    expect(observers).toHaveLength(1)
+    intersect(observers[0], [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/svelte')
+  })
+
   it('데스크탑에서는 viewport 데이터 선로딩을 추가하지 않는다', () => {
     vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true } as MediaQueryList))
 
@@ -280,6 +379,43 @@ describe('preloadDataOnViewport', () => {
 
     expect(preloadDataMock).toHaveBeenCalledOnce()
     expect(preloadDataMock).toHaveBeenCalledWith('/about')
+  })
+
+  it('화면 너비가 바뀌면 모바일 후보 등록 상태를 갱신한다', async () => {
+    const listeners = new Set<() => void>()
+    const mediaQuery = {
+      matches: false,
+      addEventListener: vi.fn((_type: string, listener: () => void) => listeners.add(listener)),
+      removeEventListener: vi.fn((_type: string, listener: () => void) =>
+        listeners.delete(listener)
+      )
+    }
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mediaQuery as unknown as MediaQueryList))
+    const node = document.createElement('a')
+
+    createAction(node, { href: '/tags/svelte' })
+
+    expect(observers).toHaveLength(1)
+    expect(observers[0].observe).toHaveBeenCalledWith(node)
+    expect(mediaQuery.addEventListener).toHaveBeenCalledOnce()
+
+    mediaQuery.matches = true
+    for (const listener of listeners) listener()
+
+    expect(observers[0].unobserve).toHaveBeenCalledWith(node)
+    expect(observers[0].disconnect).toHaveBeenCalledOnce()
+
+    mediaQuery.matches = false
+    for (const listener of listeners) listener()
+
+    expect(observers).toHaveLength(2)
+    expect(observers[1].observe).toHaveBeenCalledWith(node)
+
+    intersect(observers[1], [entry(node)])
+    await Promise.resolve()
+
+    expect(preloadDataMock).toHaveBeenCalledOnce()
+    expect(preloadDataMock).toHaveBeenCalledWith('/tags/svelte')
   })
 
   it('비활성화되거나 목적지가 없으면 관찰하지 않는다', () => {

--- a/src/lib/actions/preload-data-on-viewport.ts
+++ b/src/lib/actions/preload-data-on-viewport.ts
@@ -1,4 +1,5 @@
 import { preloadData } from '$app/navigation'
+import { page } from '$app/stores'
 import { createOptimizedIntersectionObserver } from '$lib/utils/performance'
 
 interface NetworkInformation {
@@ -25,15 +26,79 @@ interface PreloadCandidate {
 }
 
 const candidates = new Map<HTMLAnchorElement, PreloadCandidate>()
+const desktopMediaQueryListeners = new Set<() => void>()
 
 let activePreloadHref: string | null = null
+let currentPageUrl: URL | null = null
+let desktopMediaQuery: MediaQueryList | null | undefined
 let observer: IntersectionObserver | null = null
 let observerGeneration = 0
 let selectionScheduled = false
+let unsubscribeFromPage: (() => void) | null = null
+
+const getDesktopMediaQuery = (): MediaQueryList | null => {
+  if (desktopMediaQuery !== undefined) return desktopMediaQuery
+
+  desktopMediaQuery =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? (window.matchMedia('(min-width: 768px)') ?? null)
+      : null
+  return desktopMediaQuery
+}
+
+const notifyDesktopMediaQueryListeners = (): void => {
+  for (const listener of desktopMediaQueryListeners) {
+    listener()
+  }
+}
+
+const subscribeToDesktopMediaQuery = (listener: () => void): (() => void) => {
+  const mediaQuery = getDesktopMediaQuery()
+  if (!mediaQuery) {
+    return () => {
+      desktopMediaQuery = undefined
+    }
+  }
+
+  desktopMediaQueryListeners.add(listener)
+  if (desktopMediaQueryListeners.size === 1) {
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', notifyDesktopMediaQueryListeners)
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(notifyDesktopMediaQueryListeners)
+    }
+  }
+
+  return () => {
+    desktopMediaQueryListeners.delete(listener)
+    if (desktopMediaQueryListeners.size > 0) return
+
+    if (typeof mediaQuery.removeEventListener === 'function') {
+      mediaQuery.removeEventListener('change', notifyDesktopMediaQueryListeners)
+    } else if (typeof mediaQuery.removeListener === 'function') {
+      mediaQuery.removeListener(notifyDesktopMediaQueryListeners)
+    }
+    desktopMediaQuery = undefined
+  }
+}
+
+const isCurrentLocation = (href: string): boolean => {
+  try {
+    const location = currentPageUrl ?? new URL(window.location.href)
+    const target = new URL(href, location)
+    return (
+      target.origin === location.origin &&
+      target.pathname === location.pathname &&
+      target.search === location.search
+    )
+  } catch {
+    return false
+  }
+}
 
 const shouldSkipPreload = (options: PreloadDataOnViewportOptions): boolean => {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return true
-  if (options.deviceScope !== 'all' && window.matchMedia('(min-width: 768px)').matches) {
+  if (options.deviceScope !== 'all' && getDesktopMediaQuery()?.matches) {
     return true
   }
 
@@ -43,7 +108,9 @@ const shouldSkipPreload = (options: PreloadDataOnViewportOptions): boolean => {
 const selectDominantCandidate = (): void => {
   selectionScheduled = false
 
-  const visibleCandidates = Array.from(candidates.values()).filter((candidate) => candidate.visible)
+  const visibleCandidates = Array.from(candidates.values()).filter(
+    (candidate) => candidate.visible && !isCurrentLocation(candidate.href)
+  )
   if (visibleCandidates.length === 0) {
     activePreloadHref = null
     return
@@ -108,6 +175,24 @@ const ensureObserver = (): IntersectionObserver | null => {
   return observer
 }
 
+const ensurePageSubscription = (): void => {
+  if (unsubscribeFromPage) return
+
+  unsubscribeFromPage = page.subscribe(($page) => {
+    const locationChanged =
+      currentPageUrl !== null &&
+      (currentPageUrl.origin !== $page.url.origin ||
+        currentPageUrl.pathname !== $page.url.pathname ||
+        currentPageUrl.search !== $page.url.search)
+
+    currentPageUrl = $page.url
+    if (locationChanged) {
+      activePreloadHref = null
+    }
+    scheduleCandidateSelection()
+  })
+}
+
 const unregisterCandidate = (node: HTMLAnchorElement): void => {
   observer?.unobserve(node)
   candidates.delete(node)
@@ -117,6 +202,9 @@ const unregisterCandidate = (node: HTMLAnchorElement): void => {
     observer = null
     observerGeneration += 1
     activePreloadHref = null
+    unsubscribeFromPage?.()
+    unsubscribeFromPage = null
+    currentPageUrl = null
     return
   }
 
@@ -128,7 +216,9 @@ const registerCandidate = (
   options: PreloadDataOnViewportOptions
 ): boolean => {
   const href = options.href?.trim()
-  if (options.enabled === false || !href || shouldSkipPreload(options)) return false
+  if (options.enabled === false || !href || shouldSkipPreload(options)) {
+    return false
+  }
 
   const sharedObserver = ensureObserver()
   if (!sharedObserver) return false
@@ -141,6 +231,7 @@ const registerCandidate = (
     visible: false
   })
   sharedObserver.observe(node)
+  ensurePageSubscription()
   return true
 }
 
@@ -149,7 +240,32 @@ export const preloadDataOnViewport = (
   initialOptions: PreloadDataOnViewportOptions = {}
 ) => {
   let options = initialOptions
+  let unsubscribeFromDesktopMediaQuery: (() => void) | null = null
   let registered = registerCandidate(node, options)
+
+  const reconcileDeviceScope = (): void => {
+    const href = options.href?.trim()
+    const shouldRegister = options.enabled !== false && !!href && !shouldSkipPreload(options)
+
+    if (registered && !shouldRegister) {
+      unregisterCandidate(node)
+      registered = false
+    } else if (!registered && shouldRegister) {
+      registered = registerCandidate(node, options)
+    }
+  }
+
+  const syncDesktopMediaQuerySubscription = (): void => {
+    const needsSubscription = options.deviceScope !== 'all'
+    if (needsSubscription && !unsubscribeFromDesktopMediaQuery) {
+      unsubscribeFromDesktopMediaQuery = subscribeToDesktopMediaQuery(reconcileDeviceScope)
+    } else if (!needsSubscription && unsubscribeFromDesktopMediaQuery) {
+      unsubscribeFromDesktopMediaQuery()
+      unsubscribeFromDesktopMediaQuery = null
+    }
+  }
+
+  syncDesktopMediaQuerySubscription()
 
   return {
     update(nextOptions: PreloadDataOnViewportOptions = {}): void {
@@ -165,6 +281,7 @@ export const preloadDataOnViewport = (
       }
 
       options = nextOptions
+      syncDesktopMediaQuerySubscription()
       registered = registerCandidate(node, options)
     },
     destroy(): void {
@@ -172,6 +289,8 @@ export const preloadDataOnViewport = (
         unregisterCandidate(node)
         registered = false
       }
+      unsubscribeFromDesktopMediaQuery?.()
+      unsubscribeFromDesktopMediaQuery = null
     }
   }
 }

--- a/src/lib/components/TagCloud.svelte
+++ b/src/lib/components/TagCloud.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { preloadDataOnViewport } from '$lib/actions/preload-data-on-viewport'
+
   export let tagInfos: Array<{ tag: string; count: number }> = []
   export let getTagUrl: (tagName: string) => string = (tagName: string) =>
     `/tags/${encodeURIComponent(tagName)}`
@@ -59,12 +61,16 @@
       <!-- 컴팩트 모드: 작은 태그들 -->
       <div class="flex flex-wrap gap-1">
         {#each tagInfos as { tag, count }}
+          {@const href = getTagUrl(tag)}
           {#if clickable}
             <a
-              href={getTagUrl(tag)}
+              {href}
               class={getCompactTagClasses(tag, count)}
               title={`${tag} (${count}개 포스트)`}
               aria-label={`${tag} 태그, ${count}개 포스트`}
+              data-sveltekit-preload-data="hover"
+              data-sveltekit-preload-code="viewport"
+              use:preloadDataOnViewport={{ href }}
             >
               #{tag}
             </a>
@@ -83,12 +89,16 @@
       <!-- 기본 모드: 태그 클라우드 -->
       <div class="flex flex-wrap justify-center items-start gap-2 px-4 py-8">
         {#each tagInfos as { tag, count }}
+          {@const href = getTagUrl(tag)}
           {#if clickable}
             <a
-              href={getTagUrl(tag)}
+              {href}
               class={getTagClasses(tag, count)}
               title={`${tag} (${count}개 포스트)`}
               aria-label={`${tag} 태그, ${count}개 포스트`}
+              data-sveltekit-preload-data="hover"
+              data-sveltekit-preload-code="viewport"
+              use:preloadDataOnViewport={{ href }}
             >
               #{tag}
               <span class="ml-1 text-xs opacity-75">({count})</span>

--- a/src/lib/components/TagCloud.test.ts
+++ b/src/lib/components/TagCloud.test.ts
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+
+import TagCloud from './TagCloud.svelte'
+
+describe('TagCloud 컴포넌트', () => {
+  const tagInfos = [
+    { tag: 'Svelte', count: 3 },
+    { tag: 'TypeScript', count: 2 }
+  ]
+
+  it('클릭 가능한 태그 링크에 선로딩 힌트를 제공한다', () => {
+    render(TagCloud, { tagInfos, clickable: true })
+
+    const link = screen.getByRole('link', { name: 'Svelte 태그, 3개 포스트' })
+    expect(link).toHaveAttribute('href', '/tags/Svelte')
+    expect(link).toHaveAttribute('data-sveltekit-preload-data', 'hover')
+    expect(link).toHaveAttribute('data-sveltekit-preload-code', 'viewport')
+  })
+
+  it('클릭할 수 없는 태그에는 링크 선로딩 속성을 추가하지 않는다', () => {
+    render(TagCloud, { tagInfos, clickable: false })
+
+    const tag = screen.getByLabelText('Svelte 태그, 3개 포스트')
+    expect(tag.tagName).toBe('SPAN')
+    expect(tag).not.toHaveAttribute('data-sveltekit-preload-data')
+    expect(tag).not.toHaveAttribute('data-sveltekit-preload-code')
+  })
+})

--- a/src/lib/components/post/PostPreview.svelte
+++ b/src/lib/components/post/PostPreview.svelte
@@ -2,6 +2,7 @@
   import { Card } from '../ui/Card'
   import { ArrowRightIcon } from '../ui/Icon'
 
+  import { preloadDataOnViewport } from '$lib/actions/preload-data-on-viewport'
   import type { PostMetadata } from '$lib/types'
   import { createSafeSlug } from '$lib/utils/posts'
   import { TAG_STYLES } from '$lib/utils/tag-styles'
@@ -42,10 +43,13 @@
     {@html post.preview.html ?? ''}
     <div class="flex flex-wrap gap-2 mt-2">
       {#each visibleTags as tag}
+        {@const href = `/tags/${encodeURIComponent(tag)}`}
         <a
-          href="/tags/{encodeURIComponent(tag)}"
+          {href}
           class={tagClass}
-          data-sveltekit-preload-data="tap"
+          data-sveltekit-preload-data="hover"
+          data-sveltekit-preload-code="viewport"
+          use:preloadDataOnViewport={{ href }}
           aria-label={`${tag} 태그 글 보기`}
         >
           #{tag}

--- a/src/lib/components/post/PostPreview.test.ts
+++ b/src/lib/components/post/PostPreview.test.ts
@@ -122,7 +122,8 @@ describe('PostPreview 컴포넌트', () => {
 
     const jsTag = screen.getByText('#JavaScript')
     const link = jsTag.closest('a')
-    expect(link).toHaveAttribute('data-sveltekit-preload-data', 'tap')
+    expect(link).toHaveAttribute('data-sveltekit-preload-data', 'hover')
+    expect(link).toHaveAttribute('data-sveltekit-preload-code', 'viewport')
   })
 
   it('특수 문자가 포함된 태그가 올바르게 인코딩된다', () => {
@@ -227,6 +228,7 @@ describe('PostPreview 컴포넌트', () => {
       'whitespace-nowrap'
     )
     expect(tagButton).toHaveClass('cursor-pointer')
+    expect(tagButton).toHaveClass('relative', 'z-30')
   })
 
   it('더보기 버튼에 올바른 스타일이 적용된다', () => {

--- a/src/lib/components/post/TagList.svelte
+++ b/src/lib/components/post/TagList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
 
+  import { preloadDataOnViewport } from '$lib/actions/preload-data-on-viewport'
   import { generateTagClasses } from '$lib/utils/tag-styles'
 
   export let tags: string[] = []
@@ -43,30 +44,13 @@
     return generateTagClasses(tag, selectedTag, clickable)
   }
 
-  // 태그 엘리먼트 타입 결정
-  const getTagElementType = (clickable: boolean, hasClickHandler: boolean): string => {
-    if (hasClickHandler) return 'button'
-    if (clickable) return 'a'
-    return 'span'
-  }
-
   // 태그 엘리먼트 속성 생성
-  const getTagProps = (tag: string, clickable: boolean, hasClickHandler: boolean) => {
-    const baseProps = {
+  const getTagProps = (tag: string, clickable: boolean) => {
+    return {
       class: getTagClasses(tag, clickable),
       'aria-current': (selectedTag === tag ? 'page' : undefined) as 'page' | undefined,
       'data-testid': `tag-item-${tag}`
     }
-
-    if (hasClickHandler) {
-      return { ...baseProps, type: 'button' }
-    }
-
-    if (clickable) {
-      return { ...baseProps, href: getTagUrl(tag) }
-    }
-
-    return baseProps
   }
 </script>
 
@@ -79,22 +63,26 @@
     >
       {#each tags as tag}
         {@const hasClickHandler = !!(handleTagClick && clickable)}
-        {@const elementType = getTagElementType(clickable, hasClickHandler)}
-        {@const elementProps = getTagProps(tag, clickable, hasClickHandler)}
+        {@const elementProps = getTagProps(tag, clickable)}
 
         {#if hasClickHandler && handleTagClick}
-          <svelte:element
-            this={elementType}
+          <button {...elementProps} type="button" on:click={() => handleTagClick(tag)}>
+            #{tag}
+          </button>
+        {:else if clickable}
+          <a
             {...elementProps}
-            role={elementType === 'span' ? 'button' : undefined}
-            on:click={() => handleTagClick(tag)}
+            href={getTagUrl(tag)}
+            data-sveltekit-preload-data="hover"
+            data-sveltekit-preload-code="viewport"
+            use:preloadDataOnViewport={{ href: getTagUrl(tag) }}
           >
             #{tag}
-          </svelte:element>
+          </a>
         {:else}
-          <svelte:element this={elementType} {...elementProps}>
+          <span {...elementProps}>
             #{tag}
-          </svelte:element>
+          </span>
         {/if}
       {/each}
     </div>

--- a/src/lib/components/post/TagList.test.ts
+++ b/src/lib/components/post/TagList.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/svelte'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import TagList from './TagList.svelte'
 
@@ -29,10 +29,6 @@ Object.defineProperty(HTMLDivElement.prototype, 'removeEventListener', {
 describe('TagList 컴포넌트', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
   })
 
   it('태그 목록이 올바르게 렌더링된다', () => {
@@ -94,7 +90,10 @@ describe('TagList 컴포넌트', () => {
     render(TagList, { tags, clickable: true })
 
     const jsTag = screen.getByTestId('tag-item-JavaScript')
-    expect(jsTag.closest('a')).toHaveAttribute('href', '/tags/JavaScript')
+    const tagLink = jsTag.closest('a')
+    expect(tagLink).toHaveAttribute('href', '/tags/JavaScript')
+    expect(tagLink).toHaveAttribute('data-sveltekit-preload-data', 'hover')
+    expect(tagLink).toHaveAttribute('data-sveltekit-preload-code', 'viewport')
   })
 
   it('clickable이 false일 때 태그가 링크로 동작하지 않는다', () => {

--- a/src/lib/components/ui/Card/Card.svelte
+++ b/src/lib/components/ui/Card/Card.svelte
@@ -42,7 +42,7 @@
 
   {#if $$slots.description}
     <div
-      class="relative z-10 flex-1 text-sm text-zinc-600 dark:text-zinc-400"
+      class="relative flex-1 text-sm text-zinc-600 dark:text-zinc-400"
       class:mt-2={!!$$slots.title}
     >
       <slot name="description" />


### PR DESCRIPTION
## What changed

- Preload tag result route code in the viewport and data for the dominant visible mobile tag.
- Enable hover data preloading for desktop tag links across post cards, post headers, and the tag cloud.
- Keep tag chips above the card-wide link overlay so taps reach the tag itself.
- Skip the current page during candidate selection, re-evaluate after client navigation, and keep mobile registration in sync with viewport changes.
- Add action and component regression coverage.

## Why

Tag result pages were not fetched until touch/click, and the card-wide overlay could intercept tag taps. The shared candidate selector keeps mobile data preloading bounded to one useful visible destination.

## Validation

- Full Vitest suite
- `pnpm check`
- `git diff --check`
- Mobile 390×844 browser smoke: tag `__data.json` requested before click and tag chip remained the hit target
- Final read-only adversarial review: no actionable findings