### PR TITLE
ci: pin pnpm 10.32.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: pnpm 설정
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Node.js 설정
         uses: actions/setup-node@v7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "sveltekit-blog-template",
 	"version": "0.0.1",
+	"packageManager": "pnpm@10.32.1",
 	"sideEffects": [
 		"**/*.css",
 		"**/*.scss",


### PR DESCRIPTION
## Summary

- declare `pnpm@10.32.1` as the repository package-manager contract
- let `pnpm/action-setup` read that exact version instead of tracking `latest`

## Why

The dependency-security PRs exposed a CI drift: `pnpm/action-setup@v6` resolved `latest` to pnpm 11.17.0. pnpm 11 no longer reads `package.json#pnpm.overrides`, so every frozen install failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` even though the lockfiles were valid under the repository's pnpm 10 contract.

Pinning the version in `package.json` restores deterministic local and CI behavior and keeps the existing lockfile/override format unchanged.

## Impact

No application dependency, lockfile, runtime code, or public contract changes. CI and Corepack now use the same pnpm 10.32.1 version.

## Validation

- `corepack pnpm --version` → 10.32.1
- frozen install on Node 24
- `pnpm check`
- `pnpm lint` (0 errors; 44 existing warnings)
- `pnpm test:run` (274 passed)
- `pnpm build`
- `pnpm seo:validate:built` (73/73 pages valid)