### PR TITLE
fix: resolve CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 테스트 및 코드 품질 검사

--- a/scripts/vercel-build-optimize.js
+++ b/scripts/vercel-build-optimize.js
@@ -32,10 +32,7 @@ if (isVercelBuild) {
   buildEnv.VITE_BUILD_MODE = 'vercel'
   buildEnv.CI = 'true'
 
-  console.log('⚡ Vercel environment variables configured:')
-  console.log(`   VERCEL_ENV: ${buildEnv.VERCEL_ENV}`)
-  console.log(`   VERCEL_URL: ${buildEnv.VERCEL_URL}`)
-  console.log(`   VERCEL_REGION: ${buildEnv.VERCEL_REGION}`)
+  console.log('⚡ Vercel build environment configured')
 } else {
   console.log('🏠 Running in local environment')
   buildEnv.VITE_BUILD_MODE = 'local'


### PR DESCRIPTION
## Summary
- set the workflow token default to read-only contents access
- stop logging Vercel environment values during build optimization
- preserve the existing explicit permissions for the coverage comment job

## Validation
- pnpm check
- pnpm lint (warnings only)
- pnpm test (274 tests)
- pnpm build
- git diff --check
- read-only adversarial review: no actionable findings